### PR TITLE
Update to sonar 6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.sonarsource.parent</groupId>
         <artifactId>parent</artifactId>
-        <version>24</version>
+        <version>40</version>
     </parent>
     <groupId>org.sonarsource.owasp</groupId>
     <artifactId>sonar-zap</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,10 @@
             <email>steve.springett@owasp.org</email>
             <url>http://www.stevespringett.com</url>
         </developer>
+        <developer>
+            <name>Niklas Mehner</name>
+            <email>niklas.mehner@gmail.com</email>
+        </developer>
     </developers>
 
     <!-- todo: change the URLs to the new owner of the repo -->

--- a/sonar-zap-plugin/pom.xml
+++ b/sonar-zap-plugin/pom.xml
@@ -13,14 +13,14 @@
     <url>https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project</url>
 
     <properties>
-        <sonar.version>5.1</sonar.version>
+        <sonar.version>6.3</sonar.version>
         <sonar.pluginClass>org.sonar.zaproxy.ZapPlugin</sonar.pluginClass>
         <sonar.pluginName>ZAP</sonar.pluginName>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>org.codehaus.sonar</groupId>
+            <groupId>org.sonarsource.sonarqube</groupId>
             <artifactId>sonar-plugin-api</artifactId>
             <version>${sonar.version}</version>
             <scope>provided</scope>

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ZapPlugin.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ZapPlugin.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,38 +13,36 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy;
 
-import org.sonar.api.SonarPlugin;
+import org.sonar.api.Plugin;
+import org.sonar.zaproxy.base.ZapMetrics;
 import org.sonar.zaproxy.rule.ZapLanguage;
 import org.sonar.zaproxy.rule.ZapProfile;
 import org.sonar.zaproxy.rule.ZapRuleDefinition;
 import org.sonar.zaproxy.ui.ZapWidget;
-import org.sonar.zaproxy.base.ZapMetrics;
 
-import java.util.Arrays;
-import java.util.List;
-
-public final class ZapPlugin extends SonarPlugin {
+public final class ZapPlugin implements Plugin {
 
     public static final String REPOSITORY_KEY = "ZAProxy";
     public static final String LANGUAGE_KEY = "zap";
     public static final String LANGUAGE_NAME = "ZAP";
     public static final String RULES_FILE = "/org/sonar/zaproxy/rules.xml";
+    public static final String RULE_KEY = "ZapVulnerability";
 
-    @Override
-    public List getExtensions() {
-        return Arrays.asList(
-                ZapSensor.class,
-                ZapSensorConfiguration.class,
-                ZapMetrics.class,
-                ZapProfile.class,
-                ZapLanguage.class,
-                ZapRuleDefinition.class,
-                ZapWidget.class);
-    }
+		@Override
+		public void define(Context context) {
+			context.addExtensions(ZapSensor.class,
+          ZapSensorConfiguration.class,
+          ZapMetrics.class,
+          ZapProfile.class,
+          ZapLanguage.class,
+          ZapRuleDefinition.class,
+          ZapWidget.class);
+			
+		}
 }

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ZapPlugin.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ZapPlugin.java
@@ -32,8 +32,7 @@ public final class ZapPlugin implements Plugin {
     public static final String LANGUAGE_KEY = "zap";
     public static final String LANGUAGE_NAME = "ZAP";
     public static final String RULES_FILE = "/org/sonar/zaproxy/rules.xml";
-    public static final String RULE_KEY = "ZapVulnerability";
-
+ 
 		@Override
 		public void define(Context context) {
 			context.addExtensions(ZapSensor.class,

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ZapSensor.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ZapSensor.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,180 +13,167 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy;
 
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.xml.parsers.ParserConfigurationException;
+
 import org.apache.commons.lang.StringUtils;
-import org.sonar.api.batch.Sensor;
-import org.sonar.api.batch.SensorContext;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.rule.Rules;
-import org.sonar.api.component.ResourcePerspectives;
-import org.sonar.api.issue.Issuable;
-import org.sonar.api.issue.Issue;
-import org.sonar.api.resources.Project;
-import org.sonar.api.resources.Resource;
+import org.sonar.api.batch.rule.Severity;
+import org.sonar.api.batch.sensor.Sensor;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.batch.sensor.issue.internal.DefaultIssueLocation;
 import org.sonar.api.rule.RuleKey;
-import org.sonar.api.rule.Severity;
 import org.sonar.api.scan.filesystem.PathResolver;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.api.utils.log.Profiler;
-import org.sonar.zaproxy.base.ZapUtils;
 import org.sonar.zaproxy.base.ZapMetrics;
+import org.sonar.zaproxy.base.ZapUtils;
 import org.sonar.zaproxy.parser.ReportParser;
 import org.sonar.zaproxy.parser.XmlReportFile;
 import org.sonar.zaproxy.parser.element.AlertItem;
 import org.sonar.zaproxy.parser.element.ZapReport;
 import org.xml.sax.SAXException;
 
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.IOException;
-import java.io.InputStream;
-
 public class ZapSensor implements Sensor {
+	private static final String SENSOR_NAME = "OWASP Zap-Check";
+	private static final Logger LOGGER = Loggers.get(ZapSensor.class);
 
-    private static final Logger LOGGER = Loggers.get(ZapSensor.class);
+	private final Rules rules;
+	private final XmlReportFile report;
 
-    private final ResourcePerspectives resourcePerspectives;
-    private final Rules rules;
-    private final XmlReportFile report;
+	private int totalAlerts;
+	private int criticalIssuesCount;
+	private int majorIssuesCount;
+	private int minorIssuesCount;
+	private int infoIssuesCount;
 
-    private int totalAlerts;
-    private int criticalIssuesCount;
-    private int majorIssuesCount;
-    private int minorIssuesCount;
-    private int infoIssuesCount;
+	public ZapSensor(
+			ZapSensorConfiguration configuration,
+			FileSystem fileSystem,
+			PathResolver pathResolver,
+			Rules rules) {
+		this.rules = rules;
+		this.report = new XmlReportFile(configuration, fileSystem, pathResolver);
+	}
 
+	private void addIssue(org.sonar.api.batch.sensor.SensorContext context, AlertItem alert) {
+		Severity severity = ZapUtils.riskCodeToSonarQubeSeverity(alert.getRiskcode());
+		context.newIssue()
+				.forRule(RuleKey.of(ZapPlugin.REPOSITORY_KEY, ZapPlugin.RULE_KEY))
+				.at(new DefaultIssueLocation().on(context.module()).message(formatDescription(alert)))
+				.overrideSeverity(severity)
+				.save();
 
-    public ZapSensor(
-            ZapSensorConfiguration configuration,
-            ResourcePerspectives resourcePerspectives,
-            FileSystem fileSystem,
-            PathResolver pathResolver,
-            Rules rules) {
-        this.resourcePerspectives = resourcePerspectives;
-        this.rules = rules;
-        this.report = new XmlReportFile(configuration, fileSystem, pathResolver);
-    }
+		incrementCount(severity);
+	}
 
-    @Override
-    public boolean shouldExecuteOnProject(Project project) {
-        return this.report.exist();
-    }
+	/**
+	 * todo: Add Markdown formatting if and when Sonar supports it https://jira.codehaus.org/browse/SONAR-4161
+	 */
+	private String formatDescription(AlertItem alert) {
+		StringBuilder sb = new StringBuilder();
 
-    private void addIssue(Project project, AlertItem alert) {
-        Issuable issuable = this.resourcePerspectives.as(Issuable.class, (Resource)project);
-        if (issuable != null) {
-            String severity = ZapUtils.riskCodeToSonarQubeSeverity(alert.getRiskcode());
-            String pluginid = String.valueOf(alert.getPluginid());
-            // Check if the rule with the pluginid exists
-            if(rules.find(RuleKey.of(ZapPlugin.REPOSITORY_KEY, pluginid)) != null) {
-                Issue issue = issuable.newIssueBuilder()
-                        .ruleKey(RuleKey.of(ZapPlugin.REPOSITORY_KEY, pluginid))
-                        .message(formatDescription(alert))
-                        .severity(severity)
-                        .build();
-                if (issuable.addIssue(issue)) {
-                    incrementCount(severity);
-                }
+		sb.append(addValueToDescription("URI", alert.getUri(), false));
+		sb.append(addValueToDescription("Confidence", String.valueOf(alert.getConfidence()), false));
+		sb.append(addValueToDescription("Description", alert.getDesc(), false));
+		sb.append(addValueToDescription("Param", alert.getParam(), false));
+		sb.append(addValueToDescription("Attack", alert.getAttack(), false));
+		sb.append(addValueToDescription("Evidence", alert.getEvidence(), true));
 
-            } else {
-                LOGGER.warn("The rule " + ZapPlugin.REPOSITORY_KEY + ":" + pluginid + " doesn't exist.");
-            }
-        }
-    }
+		return sb.toString();
+	}
 
-    /**
-     *      todo: Add Markdown formatting if and when Sonar supports it
-     *      https://jira.codehaus.org/browse/SONAR-4161
-     */
-    private String formatDescription(AlertItem alert) {
-        StringBuilder sb = new StringBuilder();
+	private String addValueToDescription(String name, String value, boolean isEnd) {
+		StringBuilder sb = new StringBuilder();
+		if (!StringUtils.isBlank(value)) {
+			sb.append(name).append(": ").append(value);
+			if (!isEnd) {
+				sb.append(" | ");
+			}
+		}
+		return sb.toString();
+	}
 
-        sb.append(addValueToDescription("URI", alert.getUri(), false));
-        sb.append(addValueToDescription("Confidence", String.valueOf(alert.getConfidence()), false));
-        sb.append(addValueToDescription("Description", alert.getDesc(), false));
-        sb.append(addValueToDescription("Param", alert.getParam(), false));
-        sb.append(addValueToDescription("Attack", alert.getAttack(), false));
-        sb.append(addValueToDescription("Evidence", alert.getEvidence(), true));
+	private void incrementCount(Severity severity) {
+		switch (severity) {
+			case CRITICAL:
+				this.criticalIssuesCount++;
+				break;
+			case MAJOR:
+				this.majorIssuesCount++;
+				break;
+			case MINOR:
+				this.minorIssuesCount++;
+				break;
+			case INFO:
+				this.infoIssuesCount++;
+				break;
+		}
+	}
 
-        return sb.toString();
-    }
+	private void addIssues(org.sonar.api.batch.sensor.SensorContext context, ZapReport zapReport) {
+		if (zapReport.getSite().getAlerts() == null) {
+			return;
+		}
+		for (AlertItem alert : zapReport.getSite().getAlerts()) {
+			addIssue(context, alert);
+		}
+	}
 
-    private String addValueToDescription(String name, String value, boolean isEnd) {
-        StringBuilder sb = new StringBuilder();
-        if( !StringUtils.isBlank(value) ) {
-            sb.append(name).append(": ").append(value);
-            if(!isEnd) {
-                sb.append(" | ");
-            }
-        }
-        return sb.toString();
-    }
+	private ZapReport parseZapReport() throws IOException, ParserConfigurationException, SAXException {
+		try (InputStream stream = this.report.getInputStream()) {
+			return new ReportParser().parse(stream);
+		}
+	}
 
-    private void incrementCount(String severity) {
-        switch (severity) {
-            case Severity.CRITICAL:
-                this.criticalIssuesCount++;
-                break;
-            case Severity.MAJOR:
-                this.majorIssuesCount++;
-                break;
-            case Severity.MINOR:
-                this.minorIssuesCount++;
-                break;
-            case Severity.INFO:
-                this.infoIssuesCount++;
-                break;
-        }
-    }
+	@Override
+	public void execute(org.sonar.api.batch.sensor.SensorContext context) {
+		Profiler profiler = Profiler.create(LOGGER);
+		profiler.startInfo("Process ZAP report");
+		try {
+			ZapReport zapReport = parseZapReport();
+			totalAlerts = zapReport.getSite().getAlerts().size();
+			addIssues(context, zapReport);
+		} catch (Exception e) {
+			throw new RuntimeException(
+					"Can not process ZAP report. Ensure the report are located within the project workspace and that sonar.sources is set to reflect these paths (or set sonar.sources=.)",
+					e);
+		} finally {
+			profiler.stopInfo();
+		}
+		saveMeasures(context);
+	}
 
-    private void addIssues(Project project, ZapReport zapReport) {
-        if (zapReport.getSite().getAlerts() == null) {
-            return;
-        }
-        for (AlertItem alert : zapReport.getSite().getAlerts()) {
-            addIssue(project, alert);
-        }
-    }
+	private void saveMeasures(SensorContext context) {
+		context.newMeasure().forMetric(ZapMetrics.HIGH_RISK_ALERTS).withValue((double) criticalIssuesCount);
+		context.newMeasure().forMetric(ZapMetrics.MEDIUM_RISK_ALERTS).withValue((double) majorIssuesCount);
+		context.newMeasure().forMetric(ZapMetrics.LOW_RISK_ALERTS).withValue((double) minorIssuesCount);
+		context.newMeasure().forMetric(ZapMetrics.INFO_RISK_ALERTS).withValue((double) infoIssuesCount);
+		context.newMeasure().forMetric(ZapMetrics.TOTAL_ALERTS).withValue((double) totalAlerts);
 
-    private ZapReport parseZapReport() throws IOException, ParserConfigurationException, SAXException {
-        try (InputStream stream = this.report.getInputStream()) {
-            return new ReportParser().parse(stream);
-        }
-    }
+		context.newMeasure().forMetric(
+				ZapMetrics.IDENTIFIED_RISK_SCORE).withValue(
+				ZapMetrics.inheritedRiskScore(criticalIssuesCount, majorIssuesCount, minorIssuesCount));
+	}
 
-    public void analyse(Project project, SensorContext context) {
-        Profiler profiler = Profiler.create(LOGGER);
-        profiler.startInfo("Process ZAP report");
-        try {
-            ZapReport zapReport = parseZapReport();
-            totalAlerts = zapReport.getSite().getAlerts().size();
-            addIssues(project, zapReport);
-        } catch (Exception e) {
-            throw new RuntimeException("Can not process ZAP report. Ensure the report are located within the project workspace and that sonar.sources is set to reflect these paths (or set sonar.sources=.)", e);
-        } finally {
-            profiler.stopInfo();
-        }
-        saveMeasures(context);
-    }
+	@Override
+	public String toString() {
+		return "OWASP Zed Attack Proxy";
+	}
 
-    private void saveMeasures(SensorContext context) {
-        context.saveMeasure(ZapMetrics.HIGH_RISK_ALERTS, (double) criticalIssuesCount);
-        context.saveMeasure(ZapMetrics.MEDIUM_RISK_ALERTS, (double) majorIssuesCount);
-        context.saveMeasure(ZapMetrics.LOW_RISK_ALERTS, (double) minorIssuesCount);
-        context.saveMeasure(ZapMetrics.INFO_RISK_ALERTS, (double) infoIssuesCount);
-        context.saveMeasure(ZapMetrics.TOTAL_ALERTS, (double) totalAlerts);
-
-        context.saveMeasure(ZapMetrics.IDENTIFIED_RISK_SCORE, ZapMetrics.inheritedRiskScore(criticalIssuesCount, majorIssuesCount, minorIssuesCount));
-    }
-
-    @Override
-    public String toString() {
-        return "OWASP Zed Attack Proxy";
-    }
+	 @Override
+   public void describe(SensorDescriptor sensorDescriptor) {
+       sensorDescriptor.name(SENSOR_NAME);
+   }
 }

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ZapSensorConfiguration.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ZapSensorConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,18 +13,18 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy;
 
-import org.sonar.api.BatchExtension;
+import org.sonar.api.batch.ScannerSide;
 import org.sonar.api.config.Settings;
 import org.sonar.zaproxy.base.ZapConstants;
 
-
-public class ZapSensorConfiguration implements BatchExtension {
+@ScannerSide
+public class ZapSensorConfiguration  {
 
     private final Settings settings;
 

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/base/ZapConstants.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/base/ZapConstants.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,9 +13,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.base;
 

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/base/ZapMetrics.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/base/ZapMetrics.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,18 +13,18 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.base;
+
+import java.util.Arrays;
+import java.util.List;
 
 import org.sonar.api.measures.Metric;
 import org.sonar.api.measures.Metrics;
 import org.sonar.api.measures.SumChildValuesFormula;
-
-import java.util.Arrays;
-import java.util.List;
 
 public final class ZapMetrics implements Metrics {
 
@@ -39,7 +39,7 @@ public final class ZapMetrics implements Metrics {
     public static final String TOTAL_ALERTS_KEY = "total_alerts";
 
     public static double inheritedRiskScore(int high, int medium, int low) {
-        return (double) ((high * 5) + (medium * 3) + (low * 1));
+        return (high * 5) + (medium * 3) + (low * 1);
     }
 
     public static final Metric IDENTIFIED_RISK_SCORE = new Metric.Builder(ZapMetrics.IDENTIFIED_RISK_SCORE_KEY, "Identified Risk Score", Metric.ValueType.INT)

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/base/ZapUtils.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/base/ZapUtils.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,17 +13,17 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.base;
 
-import org.codehaus.staxmate.SMInputFactory;
-import org.sonar.api.rule.Severity;
-
 import javax.xml.stream.FactoryConfigurationError;
 import javax.xml.stream.XMLInputFactory;
+
+import org.codehaus.staxmate.SMInputFactory;
+import org.sonar.api.batch.rule.Severity;
 
 public final class ZapUtils {
 
@@ -39,7 +39,7 @@ public final class ZapUtils {
         return new SMInputFactory(xmlFactory);
     }
 
-    public static String riskCodeToSonarQubeSeverity(int riskcode) {
+    public static Severity riskCodeToSonarQubeSeverity(int riskcode) {
         if (riskcode == 3) {
             return Severity.CRITICAL;
         } else if (riskcode == 2) {

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/base/package-info.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/base/package-info.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,9 +13,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 @javax.annotation.ParametersAreNonnullByDefault package org.sonar.zaproxy.base;
 

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/package-info.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/package-info.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,9 +13,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 @javax.annotation.ParametersAreNonnullByDefault package org.sonar.zaproxy;
 

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/ReportParser.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/ReportParser.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,29 +13,28 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.parser;
-
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
-
-import org.sonar.zaproxy.base.ZapUtils;
-import org.apache.commons.lang.StringUtils;
-import org.codehaus.staxmate.SMInputFactory;
-import org.codehaus.staxmate.in.SMHierarchicCursor;
-import org.codehaus.staxmate.in.SMInputCursor;
-import org.sonar.zaproxy.parser.element.AlertItem;
-import org.sonar.zaproxy.parser.element.ZapReport;
-import org.sonar.zaproxy.parser.element.Site;
-
-import javax.xml.stream.XMLStreamException;
 
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.apache.commons.lang.StringUtils;
+import org.codehaus.staxmate.SMInputFactory;
+import org.codehaus.staxmate.in.SMHierarchicCursor;
+import org.codehaus.staxmate.in.SMInputCursor;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+import org.sonar.zaproxy.base.ZapUtils;
+import org.sonar.zaproxy.parser.element.AlertItem;
+import org.sonar.zaproxy.parser.element.Site;
+import org.sonar.zaproxy.parser.element.ZapReport;
 
 public class ReportParser {
 
@@ -87,7 +86,7 @@ public class ReportParser {
     }
 
     private Collection<AlertItem> processAlerts(SMInputCursor alertsCursor) throws XMLStreamException {
-        Collection<AlertItem> alertItemCollection = new ArrayList<AlertItem>();
+        Collection<AlertItem> alertItemCollection = new ArrayList<>();
         SMInputCursor alertItemCursor = alertsCursor.childElementCursor("alertitem");
 
         while (alertItemCursor.getNext() != null) {

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/XmlReportFile.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/XmlReportFile.java
@@ -34,59 +34,63 @@ import org.sonar.zaproxy.ZapSensorConfiguration;
 import org.sonar.zaproxy.base.ZapConstants;
 
 public class XmlReportFile {
-    private static final Logger LOGGER = Loggers.get(XmlReportFile.class);
 
-    private final ZapSensorConfiguration configuration;
-    private final FileSystem fileSystem;
-    private final PathResolver pathResolver;
+	private static final Logger LOGGER = Loggers.get(XmlReportFile.class);
 
-    private File report;
+	private final ZapSensorConfiguration configuration;
+	private final FileSystem fileSystem;
+	private final PathResolver pathResolver;
 
-    public XmlReportFile(ZapSensorConfiguration configuration, FileSystem fileSystem, PathResolver pathResolver) {
-        this.configuration = configuration;
-        this.fileSystem = fileSystem;
-        this.pathResolver = pathResolver;
-    }
+	private File report;
 
-    /**
-     * Report file, null if the property is not set.
-     *
-     * @throws org.sonar.api.utils.MessageException if the property relates to a directory or a non-existing file.
-     */
-    @CheckForNull
-    private File getReportFromProperty() {
-        String path = configuration.getReportPath();
-        if (path == null) {
-            return null;
-        }
+	public XmlReportFile(ZapSensorConfiguration configuration, FileSystem fileSystem, PathResolver pathResolver) {
+		this.configuration = configuration;
+		this.fileSystem = fileSystem;
+		this.pathResolver = pathResolver;
+	}
 
-        this.report = pathResolver.relativeFile(fileSystem.baseDir(), path);
+	/**
+	 * Report file, null if the property is not set.
+	 *
+	 * @throws org.sonar.api.utils.MessageException
+	 *           if the property relates to a directory or a non-existing file.
+	 */
+	@CheckForNull
+	private File getReportFromProperty() {
+		String path = configuration.getReportPath();
+		if (path == null) {
+			return null;
+		}
 
-        if (report != null && !report.isFile()) {
-            LOGGER.warn("ZAP report does not exist. SKIPPING. Please check property " +
-                    ZapConstants.REPORT_PATH_PROPERTY + ": " + path);
-            return null;
-        }
-        return report;
-    }
+		this.report = pathResolver.relativeFile(fileSystem.baseDir(), path);
 
-    public File getFile() {
-        if (report == null) {
-            report = getReportFromProperty();
-        }
-        return report;
-    }
+		if (report != null && !report.isFile()) {
+			LOGGER.warn(
+					"ZAP report does not exist. SKIPPING. Please check property " + ZapConstants.REPORT_PATH_PROPERTY + ": "
+							+ path);
+			return null;
+		}
+		return report;
+	}
 
-    public InputStream getInputStream() throws FileNotFoundException {
-        File reportFile = getFile();
-        if (reportFile == null) {
-            throw new FileNotFoundException("ZAP report does not exist.");
-        }
-        return new FileInputStream(reportFile);
-    }
+	public File getFile() {
+		if (report == null) {
+			report = getReportFromProperty();
+		}
+		return report;
+	}
 
-    public boolean exist() {
-        File reportFile = getReportFromProperty();
-        return reportFile != null;
-    }
+	public InputStream getInputStream() throws FileNotFoundException {
+		File reportFile = getFile();
+		if (reportFile == null) {
+			LOGGER.warn("ZAP report does not exist.");
+			return null;
+		}
+		return new FileInputStream(reportFile);
+	}
+
+	public boolean exist() {
+		File reportFile = getReportFromProperty();
+		return reportFile != null;
+	}
 }

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/XmlReportFile.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/XmlReportFile.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,11 +13,18 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.parser;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+
+import javax.annotation.CheckForNull;
 
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.scan.filesystem.PathResolver;
@@ -25,12 +32,6 @@ import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.zaproxy.ZapSensorConfiguration;
 import org.sonar.zaproxy.base.ZapConstants;
-
-import javax.annotation.CheckForNull;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
 
 public class XmlReportFile {
     private static final Logger LOGGER = Loggers.get(XmlReportFile.class);

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/AlertItem.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/AlertItem.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,9 +13,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.parser.element;
 

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/Site.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/Site.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,9 +13,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.parser.element;
 
@@ -70,7 +70,8 @@ public class Site {
         this.alerts = alerts;
     }
 
-    public String toString() {
+    @Override
+		public String toString() {
         String s = "";
         s += "host : [" + host + "]\n";
         s += "name : [" + name + "]\n";

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/ZapReport.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/ZapReport.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,9 +13,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.parser.element;
 
@@ -43,7 +43,8 @@ public class ZapReport {
         return site;
     }
 
-    public String toString() {
+    @Override
+		public String toString() {
         String s = "";
         s += "generated : [" + generated + "]\n";
         s += "versionZAP : [" + versionZAP + "]\n";

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/package-info.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/package-info.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,9 +13,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 @javax.annotation.ParametersAreNonnullByDefault package org.sonar.zaproxy.parser.element;
 

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/package-info.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/package-info.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,9 +13,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 @javax.annotation.ParametersAreNonnullByDefault package org.sonar.zaproxy.parser;
 

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/rule/ZapLanguage.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/rule/ZapLanguage.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,9 +13,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.rule;
 
@@ -35,7 +35,8 @@ public class ZapLanguage extends AbstractLanguage {
         super(ZapPlugin.LANGUAGE_KEY, ZapPlugin.LANGUAGE_NAME);
     }
 
-    public String[] getFileSuffixes() {
+    @Override
+		public String[] getFileSuffixes() {
         return new String[0];
     }
 

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/rule/ZapProfile.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/rule/ZapProfile.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,11 +13,18 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.rule;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.xml.stream.XMLStreamException;
 
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.staxmate.SMInputFactory;
@@ -33,13 +40,6 @@ import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.zaproxy.ZapPlugin;
 import org.sonar.zaproxy.base.ZapUtils;
-
-import javax.xml.stream.XMLStreamException;
-
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 public class ZapProfile extends ProfileDefinition {
 

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/rule/ZapRuleDefinition.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/rule/ZapRuleDefinition.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,14 +13,17 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.rule;
 
-import org.apache.commons.io.Charsets;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 
+import org.apache.commons.io.Charsets;
 import org.apache.commons.lang.StringUtils;
 import org.sonar.api.config.Settings;
 import org.sonar.api.server.rule.RulesDefinition;
@@ -29,10 +32,6 @@ import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.zaproxy.ZapPlugin;
 import org.sonar.zaproxy.base.ZapConstants;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 
 public class ZapRuleDefinition implements RulesDefinition {
 

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ui/ZapWidget.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ui/ZapWidget.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,9 +13,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.ui;
 

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ui/package-info.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ui/package-info.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,9 +13,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 @javax.annotation.ParametersAreNonnullByDefault package org.sonar.zaproxy.ui;
 

--- a/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/ZapPluginTest.java
+++ b/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/ZapPluginTest.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,21 +13,23 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy;
 
-import org.junit.Test;
+import static org.mockito.Mockito.mock;
 
-import static org.fest.assertions.Assertions.assertThat;
+import org.junit.Test;
+import org.sonar.api.Plugin;
 
 public class ZapPluginTest {
 
     @Test
     public void test_extensions() {
-        assertThat(new ZapPlugin().getExtensions()).isNotEmpty();
+    	final Plugin.Context context = mock(Plugin.Context.class);
+    	new ZapPlugin().define(context);
     }
 
 }

--- a/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/base/ZapUtilsTest.java
+++ b/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/base/ZapUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,29 +13,29 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.base;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.sonar.api.rule.Severity;
+import static org.fest.assertions.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.fest.assertions.Assertions.assertThat;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.sonar.api.batch.rule.Severity;
 
 @RunWith(Parameterized.class)
 public class ZapUtilsTest {
 
     private final int riskCodeSeverity;
-    private final String expectedSeverity;
+    private final Severity expectedSeverity;
 
-    public ZapUtilsTest(int riskCodeSeverity, String expectedSeverity) {
+    public ZapUtilsTest(int riskCodeSeverity, Severity expectedSeverity) {
         this.riskCodeSeverity = riskCodeSeverity;
         this.expectedSeverity = expectedSeverity;
     }

--- a/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/parser/ReportParserTest.java
+++ b/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/parser/ReportParserTest.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,22 +13,22 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.parser;
 
-import org.junit.Test;
-import org.sonar.zaproxy.parser.element.AlertItem;
-import org.sonar.zaproxy.parser.element.ZapReport;
-import org.sonar.zaproxy.parser.element.Site;
+import static org.fest.assertions.Assertions.assertThat;
 
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Iterator;
 
-import static org.fest.assertions.Assertions.assertThat;
+import org.junit.Test;
+import org.sonar.zaproxy.parser.element.AlertItem;
+import org.sonar.zaproxy.parser.element.Site;
+import org.sonar.zaproxy.parser.element.ZapReport;
 
 public class ReportParserTest {
 

--- a/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/parser/ZapSensorConfigurationTest.java
+++ b/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/parser/ZapSensorConfigurationTest.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,21 +13,20 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.parser;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.config.Settings;
 import org.sonar.zaproxy.ZapSensorConfiguration;
 import org.sonar.zaproxy.base.ZapConstants;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ZapSensorConfigurationTest {
     private Settings settings;

--- a/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/parser/ZapSensorTest.java
+++ b/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/parser/ZapSensorTest.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,16 +13,25 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.parser;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.rule.Rules;
+import org.sonar.api.batch.sensor.issue.NewIssueLocation;
+import org.sonar.api.batch.sensor.issue.internal.DefaultIssueLocation;
 import org.sonar.api.component.ResourcePerspectives;
 import org.sonar.api.issue.Issuable.IssueBuilder;
 import org.sonar.api.issue.Issue;
@@ -31,51 +40,49 @@ import org.sonar.api.scan.filesystem.PathResolver;
 import org.sonar.zaproxy.ZapSensor;
 import org.sonar.zaproxy.ZapSensorConfiguration;
 
-import java.net.URISyntaxException;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-
 public class ZapSensorTest {
-    private ZapSensorConfiguration configuration;
-    private ResourcePerspectives resourcePerspectives;
-    private FileSystem fileSystem;
-    private PathResolver pathResolver;
-    private Rules rules;
-    private ZapSensor sensor;
 
-    @Before
-    public void init() {
-        this.configuration = mock(ZapSensorConfiguration.class);
-        this.resourcePerspectives = mock(ResourcePerspectives.class);
-        this.fileSystem = mock(FileSystem.class);
-        this.pathResolver = mock(PathResolver.class);
-        this.rules = mock(Rules.class);
-        this.sensor = new ZapSensor(this.configuration, this.resourcePerspectives, this.fileSystem, this.pathResolver, this.rules);
-    }
+	private ZapSensorConfiguration configuration;
+	private ResourcePerspectives resourcePerspectives;
+	private FileSystem fileSystem;
+	private PathResolver pathResolver;
+	private Rules rules;
+	private ZapSensor sensor;
 
-    @Test
-    public void shouldExecuteOnProjectTest() {
-        assertThat(this.sensor.shouldExecuteOnProject(null)).isFalse();
-    }
+	@Before
+	public void init() {
+		this.configuration = mock(ZapSensorConfiguration.class);
+		this.resourcePerspectives = mock(ResourcePerspectives.class);
+		this.fileSystem = mock(FileSystem.class);
+		this.pathResolver = mock(PathResolver.class);
+		this.rules = mock(Rules.class);
+		this.sensor = new ZapSensor(
+				this.configuration,
+				this.fileSystem,
+				this.pathResolver,
+				this.rules);
+	}
 
-    @Test
-    public void toStringTest() {
-        assertThat(this.sensor.toString()).isEqualTo("OWASP Zed Attack Proxy");
-    }
 
-    @Test
-    public void shouldAnalyse() throws URISyntaxException {
-        //todo: Once the Sensor is capable of working properly, populate this unit test.
-    }
+	@Test
+	public void toStringTest() {
+		assertThat(this.sensor.toString()).isEqualTo("OWASP Zed Attack Proxy");
+	}
 
-    private class MockIssueBuilder implements IssueBuilder {
+	@Test
+	public void shouldAnalyse() throws URISyntaxException {
+		// todo: Once the Sensor is capable of working properly, populate this unit test.
+	}
+
+	private class MockIssueBuilder implements IssueBuilder {
 
         private RuleKey ruleKey;
         private Integer line;
         private String message;
         private String severity;
-
+        
+        private List<NewIssueLocation> issueLocation = new ArrayList<>();
+        
         @Override
         public IssueBuilder ruleKey(RuleKey ruleKey) {
             this.ruleKey = ruleKey;
@@ -118,6 +125,31 @@ public class ZapSensorTest {
         @Override
         public Issue build() {
             return null;
+        }
+        
+        @Override
+        public NewIssueLocation newLocation() {
+            return new DefaultIssueLocation();
+        }
+        
+        @Override
+        public IssueBuilder at(NewIssueLocation newIssueLocation) {
+            issueLocation.add(newIssueLocation);
+            return this;
+        }
+        
+        @Override
+        public IssueBuilder addLocation(NewIssueLocation newIssueLocation) {
+            issueLocation.add(newIssueLocation);
+            return this;
+        }
+        
+        @Override
+        public IssueBuilder addFlow(Iterable<NewIssueLocation> iterable) {
+            for (NewIssueLocation location : iterable) {
+                issueLocation.add(location);
+            }
+            return this;
         }
 
     }

--- a/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/ui/ZapWidgetTest.java
+++ b/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/ui/ZapWidgetTest.java
@@ -1,6 +1,6 @@
 /*
  * ZAP Plugin for SonarQube
- * Copyright (C) 2015 Steve Springett
+ * Copyright (C) 2015-2017 Steve Springett
  * steve.springett@owasp.org
  *
  * This program is free software; you can redistribute it and/or
@@ -13,15 +13,15 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package org.sonar.zaproxy.ui;
 
-import org.junit.Test;
-
 import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
 
 public class ZapWidgetTest {
 


### PR DESCRIPTION
This patch updates the plugin to be used with sonar 6.3+.

I made another change to prevent the plugin from failing if the zap report does not exists, since otherwise every sonar project has to include a zap report.