### PR TITLE
Sonar Criticals

### DIFF
--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ZapSensor.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ZapSensor.java
@@ -120,6 +120,8 @@ public class ZapSensor implements Sensor {
 			case INFO:
 				this.infoIssuesCount++;
 				break;
+                        default:
+                                break;
 		}
 	}
 

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/base/ZapMetrics.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/base/ZapMetrics.java
@@ -39,7 +39,7 @@ public final class ZapMetrics implements Metrics {
     public static final String TOTAL_ALERTS_KEY = "total_alerts";
 
     public static double inheritedRiskScore(int high, int medium, int low) {
-        return (high * 5) + (medium * 3) + (low * 1);
+        return (high * 5.0) + (medium * 3.0) + (low * 1.0);
     }
 
     public static final Metric IDENTIFIED_RISK_SCORE = new Metric.Builder(ZapMetrics.IDENTIFIED_RISK_SCORE_KEY, "Identified Risk Score", Metric.ValueType.INT)

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/rule/ZapRuleDefinition.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/rule/ZapRuleDefinition.java
@@ -73,7 +73,6 @@ public class ZapRuleDefinition implements RulesDefinition {
                 f = new File(rulesFilePath);
                 xmlLoader.load(repository, new FileInputStream(f), "UTF-8");
             } catch (FileNotFoundException e) {
-                e.printStackTrace();
                 LOGGER.warn("The file " + f.getAbsolutePath() + " does not exist", e);
 
                 // Load default ZAProxy rules if custom rules.xml does not exist.


### PR DESCRIPTION
Ran plugin though SonarQube analysis. It complained about the switch without a default, a cast to double from int, and removing a redundant exception stack trace.

It also complained about the complexity of a method, but it's going to have to stand for now.