### PR TITLE
Added rules for baseline scan. Added multi-site support. Added support for instances with nested URI

### DIFF
--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ZapSensor.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ZapSensor.java
@@ -88,6 +88,7 @@ public class ZapSensor implements Sensor {
 		StringBuilder sb = new StringBuilder();
 
 		if (null == alert.getInstances() || alert.getInstances().size() == 0) {
+			sb.append(addValueToDescription("URI", alert.getUri(), false));
 			sb.append(addValueToDescription("Param", alert.getParam(), false));
 			sb.append(addValueToDescription("Attack", alert.getAttack(), false));
 			sb.append(addValueToDescription("Evidence", alert.getEvidence(), true));
@@ -98,6 +99,7 @@ public class ZapSensor implements Sensor {
 				sb.append(addValueToDescription("Method", instance.getMethod(), false));
 				sb.append(addValueToDescription("Param", instance.getParam(), false));
 				sb.append(addValueToDescription("Attack", instance.getAttack(), false));
+				sb.append(addValueToDescription("Evidence", instance.getEvidence(), false));
 			}
 		}
 

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ZapSensor.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/ZapSensor.java
@@ -87,18 +87,24 @@ public class ZapSensor implements Sensor {
 	private String formatDescription(AlertItem alert) {
 		StringBuilder sb = new StringBuilder();
 
-		for (Instance instance: alert.getInstances()){
-			sb.append(addValueToDescription("URI", instance.getUri(), false));
-			sb.append(addValueToDescription("Method", instance.getMethod(), false));
-			sb.append(addValueToDescription("Param", instance.getParam(), false));
-			sb.append(addValueToDescription("Attack", instance.getAttack(), false));
+		if (null == alert.getInstances() || alert.getInstances().size() == 0) {
+			sb.append(addValueToDescription("Param", alert.getParam(), false));
+			sb.append(addValueToDescription("Attack", alert.getAttack(), false));
+			sb.append(addValueToDescription("Evidence", alert.getEvidence(), true));
+			sb.append(addValueToDescription("Method", alert.getMethod(), false));
+		} else {
+			for (Instance instance : alert.getInstances()) {
+				sb.append(addValueToDescription("URI", instance.getUri(), false));
+				sb.append(addValueToDescription("Method", instance.getMethod(), false));
+				sb.append(addValueToDescription("Param", instance.getParam(), false));
+				sb.append(addValueToDescription("Attack", instance.getAttack(), false));
+			}
 		}
 
 		sb.append(addValueToDescription("Confidence", String.valueOf(alert.getConfidence()), false));
 		sb.append(addValueToDescription("Description", alert.getDesc(), false));
-		//sb.append(addValueToDescription("Param", alert.getParam(), false));
-		//sb.append(addValueToDescription("Attack", alert.getAttack(), false));
-		//sb.append(addValueToDescription("Evidence", alert.getEvidence(), true));
+
+
 
 		return sb.toString();
 	}

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/ReportParser.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/ReportParser.java
@@ -139,6 +139,16 @@ public class ReportParser {
                     }
                     alertItem.addInstance(instance);
                 }
+            } else if ("uri".equals(nodeName)) {
+                alertItem.setUri(StringUtils.trim(childCursor.collectDescendantText(false)));
+            } else if ("param".equals(nodeName)) {
+                alertItem.setParam(StringUtils.trim(childCursor.collectDescendantText(false)));
+            } else if ("method".equals(nodeName)) {
+                alertItem.setMethod(StringUtils.trim(childCursor.collectDescendantText(false)));
+            } else if ("evidence".equals(nodeName)) {
+                alertItem.setEvidence(StringUtils.trim(childCursor.collectDescendantText(false)));
+            } else if ("attack".equals(nodeName)) {
+                alertItem.setAttack(StringUtils.trim(childCursor.collectDescendantText(false)));
             } else if ("otherinfo".equals(nodeName)) {
                 alertItem.setOtherinfo(StringUtils.trim(childCursor.collectDescendantText(false)));
             } else if ("solution".equals(nodeName)) {

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/ReportParser.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/ReportParser.java
@@ -139,10 +139,6 @@ public class ReportParser {
                     }
                     alertItem.addInstance(instance);
                 }
-//            }  else if ("attack".equals(nodeName)) {
-//                alertItem.setAttack(StringUtils.trim(childCursor.collectDescendantText(false)));
-//            } else if ("evidence".equals(nodeName)) {
-//                alertItem.setEvidence(StringUtils.trim(childCursor.collectDescendantText(false)));
             } else if ("otherinfo".equals(nodeName)) {
                 alertItem.setOtherinfo(StringUtils.trim(childCursor.collectDescendantText(false)));
             } else if ("solution".equals(nodeName)) {

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/AlertItem.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/AlertItem.java
@@ -19,6 +19,9 @@
  */
 package org.sonar.zaproxy.parser.element;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class AlertItem {
 
     private int pluginid;
@@ -27,8 +30,9 @@ public class AlertItem {
     private int confidence;
     private String riskdesc;
     private String desc;
-    private String uri;
-    private String param;
+    //private String uri;
+    //private String param;
+    private List<Instance> instances;
     private String attack;
     private String evidence;
     private String otherinfo;
@@ -85,14 +89,26 @@ public class AlertItem {
         this.desc = desc;
     }
 
+    public void addInstance(Instance instance){
+        if (this.instances == null){
+            this.instances = new ArrayList<Instance>();
+        }
+        this.instances.add(instance);
+    }
+
+    public List<Instance> getInstances(){
+        return this.instances;
+    }
+    /*
     public String getUri() {
         return uri;
     }
 
     public void setUri(String uri) {
         this.uri = uri;
-    }
+    }*/
 
+    /*
     public String getParam() {
         return param;
     }
@@ -100,6 +116,7 @@ public class AlertItem {
     public void setParam(String param) {
         this.param = param;
     }
+    */
     public String getAttack() {
         return attack;
     }
@@ -158,10 +175,18 @@ public class AlertItem {
 
     @Override
     public String toString() {
+        String instanceString="";
+        for (Instance instance : instances) {
+            instanceString += instance.toString();
+            if (instances.indexOf(instance) < instances.size()-1){
+                instanceString +=", ";
+            }
+        }
+
         return "AlertItem [pluginid=" + pluginid + ", alert=" + alert
                 + ", riskcode=" + riskcode + ", confidence=" + confidence
-                + ", riskdesc=" + riskdesc + ", desc=" + desc + ", uri=" + uri
-                + ", param=" + param + ", attack=" + attack + ", evidence="
+                + ", riskdesc=" + riskdesc + ", desc=" + desc + ", instances=[" + instanceString
+                + "], attack=" + attack + ", evidence="
                 + evidence + ", otherinfo=" + otherinfo + ", solution="
                 + solution + ", reference=" + reference + ", cweid=" + cweid
                 + ", wascid=" + wascid + "]\n";

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/AlertItem.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/AlertItem.java
@@ -30,13 +30,14 @@ public class AlertItem {
     private int confidence;
     private String riskdesc;
     private String desc;
-    //private String uri;
-    //private String param;
+    private String uri;
+    private String param;
     private List<Instance> instances;
     private String attack;
     private String evidence;
     private String otherinfo;
     private String solution;
+    private String method;
     private String reference;
     private int cweid;
     private int wascid;
@@ -99,24 +100,24 @@ public class AlertItem {
     public List<Instance> getInstances(){
         return this.instances;
     }
-    /*
+
     public String getUri() {
         return uri;
     }
 
-    public void setUri(String uri) {
-        this.uri = uri;
-    }*/
+    public void setUri(String uri) { this.uri = uri; }
 
-    /*
+    public String getMethod() { return method;
+    }
+
+    public void setMethod(String method) { this.method = method; }
+
     public String getParam() {
         return param;
     }
 
-    public void setParam(String param) {
-        this.param = param;
-    }
-    */
+    public void setParam(String param) { this.param = param; }
+
     public String getAttack() {
         return attack;
     }

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/Instance.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/Instance.java
@@ -1,0 +1,73 @@
+/*
+ * ZAP Plugin for SonarQube
+ * Copyright (C) 2015-2017 Gene Gotimer
+ * gene.gotimer@coveros.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.zaproxy.parser.element;
+
+public class Instance {
+    private String uri;
+    private String param;
+    private String method;
+    private String evidence;
+    private String attack;
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public String getParam() {
+        return param;
+    }
+
+    public void setParam(String param) {
+        this.param = param;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    public String getEvidence() {
+        return evidence;
+    }
+
+    public void setEvidence(String evidence) {
+        this.evidence = evidence;
+    }
+
+    public String getAttack() {
+        return method;
+    }
+
+    public void setAttack(String attack) {
+        this.attack = attack;
+    }
+
+    public String toString(){
+        return "{uri=" + uri + ", param=" +param + ", method=" + method + ", evidence=" + evidence + ", attack=" + attack + "}";
+    }
+
+}

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/ZapReport.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/ZapReport.java
@@ -19,16 +19,20 @@
  */
 package org.sonar.zaproxy.parser.element;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class ZapReport {
 
     private String generated;
     private String versionZAP;
     private Site site;
+    private List<Site> sites;
 
-    public ZapReport(String generated, String versionZAP, Site site) {
+    public ZapReport(String generated, String versionZAP, List<Site> sites) {
         this.generated = generated;
         this.versionZAP = versionZAP;
-        this.site = site;
+        this.sites = sites;
     }
 
     public String getGenerated() {
@@ -39,8 +43,27 @@ public class ZapReport {
         return versionZAP;
     }
 
-    public Site getSite() {
-        return site;
+    //public Site getSite() {
+//        return site;
+//    }
+
+    public List<Site> getSites(){
+        return sites;
+    }
+
+    public void addSite(Site site){
+        if (sites == null){
+            sites = new ArrayList<Site>();
+        }
+        sites.add(site);
+    }
+
+    public int getIssueCount(){
+        int count = 0;
+        for (Site site: sites){
+            count += site.getAlerts().size();
+        }
+        return count;
     }
 
     @Override
@@ -48,7 +71,7 @@ public class ZapReport {
         String s = "";
         s += "generated : [" + generated + "]\n";
         s += "versionZAP : [" + versionZAP + "]\n";
-        s += "site : [" + site + "]\n";
+        s += "sites : [" + sites.toString() + "]\n";
         return s;
     }
 

--- a/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/ZapReport.java
+++ b/sonar-zap-plugin/src/main/java/org/sonar/zaproxy/parser/element/ZapReport.java
@@ -26,7 +26,6 @@ public class ZapReport {
 
     private String generated;
     private String versionZAP;
-    private Site site;
     private List<Site> sites;
 
     public ZapReport(String generated, String versionZAP, List<Site> sites) {
@@ -42,10 +41,6 @@ public class ZapReport {
     public String getVersionZAP() {
         return versionZAP;
     }
-
-    //public Site getSite() {
-//        return site;
-//    }
 
     public List<Site> getSites(){
         return sites;

--- a/sonar-zap-plugin/src/main/resources/org/sonar/zaproxy/rules.xml
+++ b/sonar-zap-plugin/src/main/resources/org/sonar/zaproxy/rules.xml
@@ -1044,4 +1044,38 @@ If you want to add a rule, you can, following the model above.
         <tag>wascid-15</tag>
         <tag>cweid-565</tag>
     </rule>
+    <rule>
+        <key>100000</key>
+        <name>A Server Error response code was returned by the server</name>
+        <description>
+            <![CDATA[<h3>Solution :</h3>
+    <p>A response code of 400 was returned by the server.</p><p>This may indicate that the application is failing to handle unexpected input correctly.</p><p>Fix the handling of unexpected input.</p>
+    N/A
+    <h3>References:</h3>
+    <ul>
+
+    </ul>]]>
+        </description>
+        <severity>INFO</severity>
+        <status>READY</status>
+        <tag>security</tag>
+        <tag>zaproxy</tag>
+    </rule>
+    <rule>
+        <key>100001</key>
+        <name>Unexpected Content-Type was returned</name>
+        <description>
+            <![CDATA[<h3>Solution :</h3>
+    <p>A Content-Type that was returned is not one of the types expected to be returned by an API. Fix the Content-Type header.</p>
+    N/A
+    <h3>References:</h3>
+    <ul>
+
+    </ul>]]>
+        </description>
+        <severity>INFO</severity>
+        <status>READY</status>
+        <tag>security</tag>
+        <tag>zaproxy</tag>
+    </rule>
 </rules>

--- a/sonar-zap-plugin/src/main/resources/org/sonar/zaproxy/rules.xml
+++ b/sonar-zap-plugin/src/main/resources/org/sonar/zaproxy/rules.xml
@@ -2,8 +2,8 @@
 
 <!-- A rule model -->
 <!--<rule>
-		<key></key>
-		<name></name>-->
+    <key></key>
+    <name></name>-->
 
 <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
 <!--<description>
@@ -35,12 +35,12 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-	<p>Disable directory browsing. If this is required, make sure the listed files does not induce risks.</p>
-	<h3>References:</h3>
-	<ul>
-	<li><a href="http://httpd.apache.org/docs/mod/core.html#options">Directive Options</a></li>
-	<li><a href="http://alamo.satlug.org/pipermail/satlug/2002-February/000053.html">Apache Dir/Browsing Question</a></li>
-	</ul>]]>
+  <p>Disable directory browsing. If this is required, make sure the listed files does not induce risks.</p>
+  <h3>References:</h3>
+  <ul>
+  <li><a href="http://httpd.apache.org/docs/mod/core.html#options">Directive Options</a></li>
+  <li><a href="http://alamo.satlug.org/pipermail/satlug/2002-February/000053.html">Apache Dir/Browsing Question</a></li>
+  </ul>]]>
         </description>
         <severity>MAJOR</severity>
         <status>READY</status>
@@ -55,12 +55,12 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Remove the private IP address from the HTTP response body.  For comments, use JSP/ASP comment instead of HTML/JavaScript comment which can be seen by
-		client browsers.</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="https://tools.ietf.org/html/rfc1918">Address Allocation for Private Internets</a></li>
-		</ul>]]>
+    <p>Remove the private IP address from the HTTP response body.  For comments, use JSP/ASP comment instead of HTML/JavaScript comment which can be seen by
+    client browsers.</p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="https://tools.ietf.org/html/rfc1918">Address Allocation for Private Internets</a></li>
+    </ul>]]>
         </description>
         <severity>MINOR</severity>
         <status>READY</status>
@@ -75,11 +75,11 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>For secure content, put session ID in a cookie. To be even more secure consider using a combination of cookie and URL rewrite.</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="http://seclists.org/lists/webappsec/2002/Oct-Dec/0111.html">Hijacking URL Encoded Session IDs using Referer Logs</a></li>
-		</ul>]]>
+    <p>For secure content, put session ID in a cookie. To be even more secure consider using a combination of cookie and URL rewrite.</p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="http://seclists.org/lists/webappsec/2002/Oct-Dec/0111.html">Hijacking URL Encoded Session IDs using Referer Logs</a></li>
+    </ul>]]>
         </description>
         <severity>MAJOR</severity>
         <status>READY</status>
@@ -94,49 +94,49 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use a whitelist of acceptable inputs that strictly conform to
-		specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on
-		looking for malicious or malformed inputs (i.e., do not rely on a blacklist). However, blacklists can be useful for detecting potential attacks or
-		determining which inputs are so malformed that they should be rejected outright.
+    <p>Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use a whitelist of acceptable inputs that strictly conform to
+    specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on
+    looking for malicious or malformed inputs (i.e., do not rely on a blacklist). However, blacklists can be useful for detecting potential attacks or
+    determining which inputs are so malformed that they should be rejected outright.
 
-		When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or
-		extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid
-		because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
+    When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or
+    extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid
+    because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
 
-		For filenames, use stringent whitelists that limit the character set to be used. If feasible, only allow a single "." character in the filename to avoid weaknesses,
-		and exclude directory separators such as "/". Use a whitelist of allowable file extensions.
+    For filenames, use stringent whitelists that limit the character set to be used. If feasible, only allow a single "." character in the filename to avoid weaknesses,
+    and exclude directory separators such as "/". Use a whitelist of allowable file extensions.
 
-		Warning: if you attempt to cleanse your data, then do so that the end result is not in the form that can be dangerous. A sanitizing mechanism can remove characters
-		such as '.' and ';' which may be required for some exploits. An attacker can try to fool the sanitizing mechanism into "cleaning" data into a dangerous form.
-		Suppose the attacker injects a '.' inside a filename (e.g. "sensi.tiveFile") and the sanitizing mechanism removes the character resulting in the valid filename,
-		"sensitiveFile". If the input data are now assumed to be safe, then the file may be compromised.
+    Warning: if you attempt to cleanse your data, then do so that the end result is not in the form that can be dangerous. A sanitizing mechanism can remove characters
+    such as '.' and ';' which may be required for some exploits. An attacker can try to fool the sanitizing mechanism into "cleaning" data into a dangerous form.
+    Suppose the attacker injects a '.' inside a filename (e.g. "sensi.tiveFile") and the sanitizing mechanism removes the character resulting in the valid filename,
+    "sensitiveFile". If the input data are now assumed to be safe, then the file may be compromised.
 
-		Inputs should be decoded and canonicalized to the application's current internal representation before being validated. Make sure that your application does not
-		decode the same input twice. Such errors could be used to bypass whitelist schemes by introducing dangerous inputs after they have been checked.
+    Inputs should be decoded and canonicalized to the application's current internal representation before being validated. Make sure that your application does not
+    decode the same input twice. Such errors could be used to bypass whitelist schemes by introducing dangerous inputs after they have been checked.
 
-		Use a built-in path canonicalization function (such as realpath() in C) that produces the canonical version of the pathname, which effectively removes ".."
-		sequences and symbolic links.
+    Use a built-in path canonicalization function (such as realpath() in C) that produces the canonical version of the pathname, which effectively removes ".."
+    sequences and symbolic links.
 
-		Run your code using the lowest privileges that are required to accomplish the necessary tasks. If possible, create isolated accounts with limited privileges that
-		are only used for a single task. That way, a successful attack will not immediately give the attacker access to the rest of the software or its environment. For
-		example, database applications rarely need to run as the database administrator, especially in day-to-day operations.
+    Run your code using the lowest privileges that are required to accomplish the necessary tasks. If possible, create isolated accounts with limited privileges that
+    are only used for a single task. That way, a successful attack will not immediately give the attacker access to the rest of the software or its environment. For
+    example, database applications rarely need to run as the database administrator, especially in day-to-day operations.
 
-		When the set of acceptable objects, such as filenames or URLs, is limited or known, create a mapping from a set of fixed input values (such as numeric IDs) to the
-		actual filenames or URLs, and reject all other inputs.
+    When the set of acceptable objects, such as filenames or URLs, is limited or known, create a mapping from a set of fixed input values (such as numeric IDs) to the
+    actual filenames or URLs, and reject all other inputs.
 
-		Run your code in a "jail" or similar sandbox environment that enforces strict boundaries between the process and the operating system. This may effectively restrict
-		which files can be accessed in a particular directory or which commands can be executed by your software.
+    Run your code in a "jail" or similar sandbox environment that enforces strict boundaries between the process and the operating system. This may effectively restrict
+    which files can be accessed in a particular directory or which commands can be executed by your software.
 
-		OS-level examples include the Unix chroot jail, AppArmor, and SELinux. In general, managed code may provide some protection. For example, java.io.FilePermission in
-		the Java SecurityManager allows you to specify restrictions on file operations.
+    OS-level examples include the Unix chroot jail, AppArmor, and SELinux. In general, managed code may provide some protection. For example, java.io.FilePermission in
+    the Java SecurityManager allows you to specify restrictions on file operations.
 
-		This may not be a feasible solution, and it only limits the impact to the operating system; the rest of your application may still be subject to compromise.
-		</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="http://projects.webappsec.org/Path-Traversal">Path Traversal</a></li>
-		<li><a href="http://cwe.mitre.org/data/definitions/22.html">CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')</a></li>
-		</ul>]]>
+    This may not be a feasible solution, and it only limits the impact to the operating system; the rest of your application may still be subject to compromise.
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="http://projects.webappsec.org/Path-Traversal">Path Traversal</a></li>
+    <li><a href="http://cwe.mitre.org/data/definitions/22.html">CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')</a></li>
+    </ul>]]>
         </description>
         <severity>CRITICAL</severity>
         <status>READY</status>
@@ -151,58 +151,58 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Phase: Architecture and Design</p>
-		<p>
-		When the set of acceptable objects, such as filenames or URLs, is limited or known, create a mapping from a set of fixed input values (such as numeric IDs)
-		to the actual filenames or URLs, and reject all other inputs.
-		For example, ID 1 could map to "inbox.txt" and ID 2 could map to "profile.txt". Features such as the ESAPI AccessReferenceMap provide this capability.
-		</p>
-		Phases: Architecture and Design; Operation
-		<p>
-		Run your code in a "jail" or similar sandbox environment that enforces strict boundaries between the process and the operating system. This may effectively
-		restrict which files can be accessed in a particular directory or which commands can be executed by your software.
-		OS-level examples include the Unix chroot jail, AppArmor, and SELinux. In general, managed code may provide some protection. For example,
-		java.io.FilePermission in the Java SecurityManager allows you to specify restrictions on file operations.
-		This may not be a feasible solution, and it only limits the impact to the operating system; the rest of your application may still be subject to compromise.
-		Be careful to avoid CWE-243 and other weaknesses related to jails.
-		For PHP, the interpreter offers restrictions such as open basedir or safe mode which can make it more difficult for an attacker to escape out of the
-		application. Also consider Suhosin, a hardened PHP extension, which includes various options that disable some of the more dangerous PHP features.
-		</p>
-		Phase: Implementation
-		<p>
-		Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use a whitelist of acceptable inputs that strictly conform to
-		specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on
-		looking for malicious or malformed inputs (i.e., do not rely on a blacklist). However, blacklists can be useful for detecting potential attacks or
-		determining which inputs are so malformed that they should be rejected outright.
-		When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values,
-		missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be
-		syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
-		For filenames, use stringent whitelists that limit the character set to be used. If feasible, only allow a single "." character in the filename to avoid
-		weaknesses such as CWE-23, and exclude directory separators such as "/" to avoid CWE-36. Use a whitelist of allowable file extensions, which will help to
-		avoid CWE-434.
-		</p>
-		Phases: Architecture and Design; Operation
-		<p>
-		Store library, include, and utility files outside of the web document root, if possible. Otherwise, store them in a separate directory and use the web
-		server's access control capabilities to prevent attackers from directly requesting them. One common practice is to define a fixed constant in each calling
-		program, then check for the existence of the constant in the library/include file; if the constant does not exist, then the file was directly requested, and
-		it can exit immediately.
-		This significantly reduces the chance of an attacker being able to bypass any protection mechanisms that are in the base program but not in the include
-		files. It will also reduce your attack surface.
-		</p>
-		Phases: Architecture and Design; Implementation
-		<p>
-		Understand all the potential areas where untrusted inputs can enter your software: parameters or arguments, cookies, anything read from the network,
-		environment variables, reverse DNS lookups, query results, request headers, URL components, e-mail, files, databases, and any external systems that provide
-		data to the application. Remember that such inputs may be obtained indirectly through API calls.
-		Many file inclusion problems occur because the programmer assumed that certain inputs could not be modified, especially for cookies and URL components.
-		</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="http://projects.webappsec.org/Remote-File-Inclusion">Remote File Inclusion</a></li>
-		<li><a href="http://cwe.mitre.org/data/definitions/98.html">CWE-98: Improper Control of Filename for Include/Require Statement in PHP Program
-		('PHP Remote File Inclusion')</a></li>
-		</ul>]]>
+    <p>Phase: Architecture and Design</p>
+    <p>
+    When the set of acceptable objects, such as filenames or URLs, is limited or known, create a mapping from a set of fixed input values (such as numeric IDs)
+    to the actual filenames or URLs, and reject all other inputs.
+    For example, ID 1 could map to "inbox.txt" and ID 2 could map to "profile.txt". Features such as the ESAPI AccessReferenceMap provide this capability.
+    </p>
+    Phases: Architecture and Design; Operation
+    <p>
+    Run your code in a "jail" or similar sandbox environment that enforces strict boundaries between the process and the operating system. This may effectively
+    restrict which files can be accessed in a particular directory or which commands can be executed by your software.
+    OS-level examples include the Unix chroot jail, AppArmor, and SELinux. In general, managed code may provide some protection. For example,
+    java.io.FilePermission in the Java SecurityManager allows you to specify restrictions on file operations.
+    This may not be a feasible solution, and it only limits the impact to the operating system; the rest of your application may still be subject to compromise.
+    Be careful to avoid CWE-243 and other weaknesses related to jails.
+    For PHP, the interpreter offers restrictions such as open basedir or safe mode which can make it more difficult for an attacker to escape out of the
+    application. Also consider Suhosin, a hardened PHP extension, which includes various options that disable some of the more dangerous PHP features.
+    </p>
+    Phase: Implementation
+    <p>
+    Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use a whitelist of acceptable inputs that strictly conform to
+    specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on
+    looking for malicious or malformed inputs (i.e., do not rely on a blacklist). However, blacklists can be useful for detecting potential attacks or
+    determining which inputs are so malformed that they should be rejected outright.
+    When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values,
+    missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be
+    syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
+    For filenames, use stringent whitelists that limit the character set to be used. If feasible, only allow a single "." character in the filename to avoid
+    weaknesses such as CWE-23, and exclude directory separators such as "/" to avoid CWE-36. Use a whitelist of allowable file extensions, which will help to
+    avoid CWE-434.
+    </p>
+    Phases: Architecture and Design; Operation
+    <p>
+    Store library, include, and utility files outside of the web document root, if possible. Otherwise, store them in a separate directory and use the web
+    server's access control capabilities to prevent attackers from directly requesting them. One common practice is to define a fixed constant in each calling
+    program, then check for the existence of the constant in the library/include file; if the constant does not exist, then the file was directly requested, and
+    it can exit immediately.
+    This significantly reduces the chance of an attacker being able to bypass any protection mechanisms that are in the base program but not in the include
+    files. It will also reduce your attack surface.
+    </p>
+    Phases: Architecture and Design; Implementation
+    <p>
+    Understand all the potential areas where untrusted inputs can enter your software: parameters or arguments, cookies, anything read from the network,
+    environment variables, reverse DNS lookups, query results, request headers, URL components, e-mail, files, databases, and any external systems that provide
+    data to the application. Remember that such inputs may be obtained indirectly through API calls.
+    Many file inclusion problems occur because the programmer assumed that certain inputs could not be modified, especially for cookies and URL components.
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="http://projects.webappsec.org/Remote-File-Inclusion">Remote File Inclusion</a></li>
+    <li><a href="http://cwe.mitre.org/data/definitions/98.html">CWE-98: Improper Control of Filename for Include/Require Statement in PHP Program
+    ('PHP Remote File Inclusion')</a></li>
+    </ul>]]>
         </description>
         <severity>CRITICAL</severity>
         <status>READY</status>
@@ -211,20 +211,17 @@ If you want to add a rule, you can, following the model above.
         <tag>security</tag>
         <tag>zaproxy</tag>
     </rule>
-
-
-
     <rule>
         <key>10010</key>
         <name>Cookie set without HttpOnly flag</name>
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Ensure that the HttpOnly flag is set for all cookies.</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="https://www.owasp.org/index.php/HttpOnly">HttpOnly</a></li>
-		</ul>]]>
+    <p>Ensure that the HttpOnly flag is set for all cookies.</p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="https://www.owasp.org/index.php/HttpOnly">HttpOnly</a></li>
+    </ul>]]>
         </description>
         <severity>MINOR</severity>
         <status>READY</status>
@@ -235,15 +232,14 @@ If you want to add a rule, you can, following the model above.
     <rule>
         <key>10011</key>
         <name>Cookie set without secure flag</name>
-
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Whenever a cookie contains sensitive information or is a session token, then it should always be passed using an encrypted tunnel.
-		Ensure that the secure flag is set for cookies containing such sensitive information.</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="http://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)">Testing for cookies attributes (OTG-SESS-002)</a></li>
-		</ul>]]>
+    <p>Whenever a cookie contains sensitive information or is a session token, then it should always be passed using an encrypted tunnel.
+    Ensure that the secure flag is set for cookies containing such sensitive information.</p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="http://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)">Testing for cookies attributes (OTG-SESS-002)</a></li>
+    </ul>]]>
         </description>
         <severity>MINOR</severity>
         <status>READY</status>
@@ -257,11 +253,11 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Turn off AUTOCOMPLETE attribute in form or individual input elements containing password by using AUTOCOMPLETE='OFF'</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="http://msdn.microsoft.com/library/default.asp?url=/workshop/author/forms/autocomplete_ovr.asp">Autocomplete</a></li>
-		</ul>]]>
+    <p>Turn off AUTOCOMPLETE attribute in form or individual input elements containing password by using AUTOCOMPLETE='OFF'</p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="http://msdn.microsoft.com/library/default.asp?url=/workshop/author/forms/autocomplete_ovr.asp">Autocomplete</a></li>
+    </ul>]]>
         </description>
         <severity>MINOR</severity>
         <status>READY</status>
@@ -275,12 +271,12 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate, private; and that the pragma HTTP header is
-		set with no-cache.</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Web_Content_Caching">Web Content Caching</a></li>
-		</ul>]]>
+    <p>Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate, private; and that the pragma HTTP header is
+    set with no-cache.</p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Web_Content_Caching">Web Content Caching</a></li>
+    </ul>]]>
         </description>
         <severity>MINOR</severity>
         <status>READY</status>
@@ -294,12 +290,12 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet">XSS (Cross Site Scripting) Prevention Cheat Sheet</a></li>
-		<li><a href="https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers">Guidelines for Setting Security Headers</a></li>
-		</ul>]]>
+    <p>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.</p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet">XSS (Cross Site Scripting) Prevention Cheat Sheet</a></li>
+    <li><a href="https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers">Guidelines for Setting Security Headers</a></li>
+    </ul>]]>
         </description>
         <severity>MINOR</severity>
         <status>READY</status>
@@ -314,11 +310,11 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Ensure JavaScript source files are loaded from only trusted sources, and the sources can't be controlled by end users of the application</p>
-		<h3>References:</h3>
-		<ul>
-		<li>No reference.</li>
-		</ul>]]>
+    <p>Ensure JavaScript source files are loaded from only trusted sources, and the sources can't be controlled by end users of the application</p>
+    <h3>References:</h3>
+    <ul>
+    <li>No reference.</li>
+    </ul>]]>
         </description>
         <severity>MINOR</severity>
         <status>READY</status>
@@ -331,11 +327,11 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Ensure each page is setting the specific and appropriate content-type value for the content being delivered</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx">Reducing MIME type security risks</a></li>
-		</ul>]]>
+    <p>Ensure each page is setting the specific and appropriate content-type value for the content being delivered</p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx">Reducing MIME type security risks</a></li>
+    </ul>]]>
         </description>
         <severity>MINOR</severity>
         <status>READY</status>
@@ -348,13 +344,13 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Most modern Web browsers support the X-Frame-Options HTTP header. Ensure it's set on all web pages returned by your site
-		(if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise
-		if you never expect the page to be framed, you should use DENY.  ALLOW-FROM allows specific websites to frame the web page in supported web browsers).</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx">Combating ClickJacking With X-Frame-Options</a></li>
-		</ul>]]>
+    <p>Most modern Web browsers support the X-Frame-Options HTTP header. Ensure it's set on all web pages returned by your site
+    (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise
+    if you never expect the page to be framed, you should use DENY.  ALLOW-FROM allows specific websites to frame the web page in supported web browsers).</p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx">Combating ClickJacking With X-Frame-Options</a></li>
+    </ul>]]>
         </description>
         <severity>MAJOR</severity>
         <status>READY</status>
@@ -367,18 +363,129 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for
-		all web pages.</br>If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that
-		can be directed by the web application/web server to not perform MIME-sniffing.</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx">Reducing MIME type security risks</a></li>
-		<li><a href="https://www.owasp.org/index.php/List_of_useful_HTTP_headers">List of useful HTTP headers</a></li>
-		</ul>]]>
+    <p>Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to 'nosniff' for
+    all web pages.</br>If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that
+    can be directed by the web application/web server to not perform MIME-sniffing.</p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx">Reducing MIME type security risks</a></li>
+    <li><a href="https://www.owasp.org/index.php/List_of_useful_HTTP_headers">List of useful HTTP headers</a></li>
+    </ul>]]>
         </description>
         <severity>MINOR</severity>
         <status>READY</status>
         <tag>wascid-15</tag>
+        <tag>security</tag>
+        <tag>zaproxy</tag>
+    </rule>
+    <rule>
+        <key>10023</key>
+        <name>Information Disclosure - Debug Error Messages</name>
+
+        <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
+            <![CDATA[<h3>Solution :</h3>
+    <p>Disable or limit detailed error handling. In particular, do not display debug information to end users, stack traces, or path information.
+    Ensure that the entire software development team shares a common approach to exception handling.
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="https://www.owasp.org/index.php/Top_10_2007-Information_Leakage_and_Improper_Error_Handling">List of useful HTTP headers</a></li>
+    </ul>]]>
+        </description>
+        <severity>MINOR</severity>
+        <status>READY</status>
+        <tag>wascid-13</tag>
+        <tag>security</tag>
+        <tag>zaproxy</tag>
+    </rule>
+    <rule>
+        <key>10024</key>
+        <name>Information Disclosure - Sensitive Informations in URL</name>
+        <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
+            <![CDATA[<h3>Solution :</h3>
+    <p>When sensitive information is sent, use of the POST method is recommended (e.g. registration form).
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="https://www.owasp.org/index.php/Information_exposure_through_query_strings_in_url">List of useful HTTP headers</a></li>
+    </ul>]]>
+        </description>
+        <severity>MINOR</severity>
+        <status>READY</status>
+        <tag>wascid-13</tag>
+        <tag>security</tag>
+        <tag>zaproxy</tag>
+    </rule>
+    <rule>
+        <key>10025</key>
+        <name>Information Disclosure - Sensitive Information in HTTP Referrer Header</name>
+        <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
+            <![CDATA[<h3>Solution :</h3>
+    <p>When sensitive information is sent, use of the POST method is recommended (e.g. registration form).
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="https://www.owasp.org/index.php/Information_exposure_through_query_strings_in_url">List of useful HTTP headers</a></li>
+    </ul>]]>
+        </description>
+        <severity>MINOR</severity>
+        <status>READY</status>
+        <tag>wascid-13</tag>
+        <tag>security</tag>
+        <tag>zaproxy</tag>
+    </rule>
+    <rule>
+        <key>10026</key>
+        <name>HTTP Parameter Override</name>
+        <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
+            <![CDATA[<h3>Solution :</h3>
+    <p>In order to prevent these kinds of vulnerabilities, an extensive and proper input validation should be performed.
+    There are safe methods to conform to with each web technology/language. Moreover, awareness about the fact that clients/users can provide more than one parameter should be raised.
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="https://www.owasp.org/index.php/Testing_for_HTTP_Parameter_pollution_(OTG-INPVAL-004)">Testing for HPP</a></li>
+    </ul>]]>
+        </description>
+        <severity>MINOR</severity>
+        <status>READY</status>
+        <tag>security</tag>
+        <tag>zaproxy</tag>
+    </rule>
+    <rule>
+        <key>10027</key>
+        <name>Information Disclosure - Suspicious Comments</name>
+        <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
+            <![CDATA[<h3>Solution :</h3>
+    <p>Remove comments that suggest the presence of bugs, incomplete functionality, or weaknesses, before deploying the application.
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="https://cwe.mitre.org/data/definitions/546.html">CWE-546</a></li>
+    </ul>]]>
+        </description>
+        <severity>INFO</severity>
+        <status>READY</status>
+        <tag>cweid-546</tag>
+        <tag>wascid-13</tag>
+        <tag>security</tag>
+        <tag>zaproxy</tag>
+    </rule>
+    <rule>
+        <key>10032</key>
+        <name>Viewstate Scanner</name>
+        <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
+            <![CDATA[<h3>Solution :</h3>
+    <p>Do not store the ViewState within the HTML page (implement a handler). Protect the ViewState contents (configuration).
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="https://www.owasp.org/images/2/22/20110412-aspnet_viewstate_security-alexandre.pdf">ASP Security ViewState flaw</a></li>
+    </ul>]]>
+        </description>
+        <severity>MINOR</severity>
+        <status>READY</status>
+        <tag>wascid-13</tag>
         <tag>security</tag>
         <tag>zaproxy</tag>
     </rule>
@@ -388,16 +495,54 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>A page that is available over TLS must be comprised completely of content which is transmitted over TLS.
-		The page must not contain any content that is transmitted over unencrypted HTTP.
-		This includes content from unrelated third party sites.</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet">Transport Layer Protection Cheat Sheet</a></li>
-		</ul>]]>
+    <p>A page that is available over TLS must be comprised completely of content which is transmitted over TLS.
+    The page must not contain any content that is transmitted over unencrypted HTTP.
+    This includes content from unrelated third party sites.</p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet">Transport Layer Protection Cheat Sheet</a></li>
+    </ul>]]>
         </description>
         <severity>MINOR</severity>
         <status>READY</status>
+        <tag>security</tag>
+        <tag>zaproxy</tag>
+    </rule>
+    <rule>
+        <key>10105</key>
+        <name>Weak Authentication Method</name>
+
+        <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
+            <![CDATA[<h3>Solution :</h3>
+    <p>Disable and block all authentication methods so that only forms-based authentication and SSL client certificates are allowed.
+    Whitelist or proxy all inlined content in order to block malicious authentication requests.
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="https://www.owasp.org/index.php/OWASP_Periodic_Table_of_Vulnerabilities_-_Weak_Authentication_Methods">Weak Authentication Methods</a></li>
+    </ul>]]>
+        </description>
+        <severity>MINOR</severity>
+        <status>READY</status>
+        <tag>security</tag>
+        <tag>zaproxy</tag>
+    </rule>
+    <rule>
+        <key>10202</key>
+        <name>Absence of Anti-CSRF Tokens</name>
+
+        <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
+            <![CDATA[<h3>Solution :</h3>
+    <p>Check standard headers to verify the request is same origin and Check CSRF token.
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet">CSRF Prevention Cheat Sheet</a></li>
+    </ul>]]>
+        </description>
+        <severity>CRITICAL</severity>
+        <status>READY</status>
+        <tag>wascid-9</tag>
         <tag>security</tag>
         <tag>zaproxy</tag>
     </rule>
@@ -407,29 +552,29 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use a whitelist of acceptable inputs that strictly conform to
-		specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on
-		looking for malicious or malformed inputs (i.e., do not rely on a blacklist). However, blacklists can be useful for detecting potential attacks or
-		determining which inputs are so malformed that they should be rejected outright.
-		When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values,
-		missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be
-		syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
-		Use a whitelist of approved URLs or domains to be used for redirection.
-		Use an intermediate disclaimer page that provides the user with a clear warning that they are leaving your site. Implement a long timeout before the
-		redirect occurs, or force the user to click on the link. Be careful to avoid XSS problems when generating the disclaimer page.
-		When the set of acceptable objects, such as filenames or URLs, is limited or known, create a mapping from a set of fixed input values (such as numeric IDs)
-		to the actual filenames or URLs, and reject all other inputs.
-		For example, ID 1 could map to "/login.asp" and ID 2 could map to "http://www.example.com/". Features such as the ESAPI AccessReferenceMap provide this
-		capability.
-		Understand all the potential areas where untrusted inputs can enter your software: parameters or arguments, cookies, anything read from the network,
-		environment variables, reverse DNS lookups, query results, request headers, URL components, e-mail, files, databases, and any external systems that provide
-		data to the application. Remember that such inputs may be obtained indirectly through API calls.
-		Many open redirect problems occur because the programmer assumed that certain inputs could not be modified, such as cookies and hidden form fields.</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="http://projects.webappsec.org/URL-Redirector-Abuse">URL Redirector Abuse</a></li>
-		<li><a href="http://cwe.mitre.org/data/definitions/601.html">CWE-601: URL Redirection to Untrusted Site ('Open Redirect')</a></li>
-		</ul>]]>
+    <p>Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use a whitelist of acceptable inputs that strictly conform to
+    specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on
+    looking for malicious or malformed inputs (i.e., do not rely on a blacklist). However, blacklists can be useful for detecting potential attacks or
+    determining which inputs are so malformed that they should be rejected outright.
+    When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values,
+    missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be
+    syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
+    Use a whitelist of approved URLs or domains to be used for redirection.
+    Use an intermediate disclaimer page that provides the user with a clear warning that they are leaving your site. Implement a long timeout before the
+    redirect occurs, or force the user to click on the link. Be careful to avoid XSS problems when generating the disclaimer page.
+    When the set of acceptable objects, such as filenames or URLs, is limited or known, create a mapping from a set of fixed input values (such as numeric IDs)
+    to the actual filenames or URLs, and reject all other inputs.
+    For example, ID 1 could map to "/login.asp" and ID 2 could map to "http://www.example.com/". Features such as the ESAPI AccessReferenceMap provide this
+    capability.
+    Understand all the potential areas where untrusted inputs can enter your software: parameters or arguments, cookies, anything read from the network,
+    environment variables, reverse DNS lookups, query results, request headers, URL components, e-mail, files, databases, and any external systems that provide
+    data to the application. Remember that such inputs may be obtained indirectly through API calls.
+    Many open redirect problems occur because the programmer assumed that certain inputs could not be modified, such as cookies and hidden form fields.</p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="http://projects.webappsec.org/URL-Redirector-Abuse">URL Redirector Abuse</a></li>
+    <li><a href="http://cwe.mitre.org/data/definitions/601.html">CWE-601: URL Redirection to Untrusted Site ('Open Redirect')</a></li>
+    </ul>]]>
         </description>
         <severity>MAJOR</severity>
         <status>READY</status>
@@ -466,12 +611,12 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Type check the submitted parameter carefully.  Do not allow CRLF to be injected by filtering CRLF.</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="http://www.securityfocus.com/bid/9804">Multiple Vendor HTTP Response Splitting Vulnerability</a></li>
-		<li><a href="https://www.owasp.org/index.php/HTTP_Response_Splitting">HTTP Response Splitting</a></li>
-		</ul>]]>
+    <p>Type check the submitted parameter carefully.  Do not allow CRLF to be injected by filtering CRLF.</p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="http://www.securityfocus.com/bid/9804">Multiple Vendor HTTP Response Splitting Vulnerability</a></li>
+    <li><a href="https://www.owasp.org/index.php/HTTP_Response_Splitting">HTTP Response Splitting</a></li>
+    </ul>]]>
         </description>
         <severity>MAJOR</severity>
         <status>READY</status>
@@ -486,12 +631,12 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Identify the cause of the error and fix it.  Do not trust client side input and enforce a tight check in the server side.  Besides, catch the exception
-		properly.  Use a generic 500 error page for internal server error.</p>
-		<h3>References:</h3>
-		<ul>
-		<li>No reference.</li>
-		</ul>]]>
+    <p>Identify the cause of the error and fix it.  Do not trust client side input and enforce a tight check in the server side.  Besides, catch the exception
+    properly.  Use a generic 500 error page for internal server error.</p>
+    <h3>References:</h3>
+    <ul>
+    <li>No reference.</li>
+    </ul>]]>
         </description>
         <severity>MAJOR</severity>
         <status>READY</status>
@@ -506,20 +651,20 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Do not trust client side input and enforce a tight check in the server side.  Disable server side includes.</br>
-		Refer to manual to disable Sever Side Include.</br>
-		Use least privilege to run your web server or application server.</br>
-		For Apache, disable the following:
-		<ul>
-		<li>Options Indexes FollowSymLinks Includes</li>
-		<li>AddType application/x-httpd-cgi .cgi</li>
-		<li>AddType text/x-server-parsed-html .html</li>
-		</ul>
-		</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="http://www.carleton.ca/~dmcfet/html/ssi.html">Server Side Includes</a></li>
-		</ul>]]>
+    <p>Do not trust client side input and enforce a tight check in the server side.  Disable server side includes.</br>
+    Refer to manual to disable Sever Side Include.</br>
+    Use least privilege to run your web server or application server.</br>
+    For Apache, disable the following:
+    <ul>
+    <li>Options Indexes FollowSymLinks Includes</li>
+    <li>AddType application/x-httpd-cgi .cgi</li>
+    <li>AddType text/x-server-parsed-html .html</li>
+    </ul>
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="http://www.carleton.ca/~dmcfet/html/ssi.html">Server Side Includes</a></li>
+    </ul>]]>
         </description>
         <severity>CRITICAL</severity>
         <status>READY</status>
@@ -534,35 +679,35 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		Phase: Architecture and Design
-		<p>
-		Use a vetted library or framework that does not allow this weakness to occur or provides constructs that make this weakness easier to avoid.
-		Examples of libraries and frameworks that make it easier to generate properly encoded output include Microsoft's Anti-XSS library, the OWASP ESAPI Encoding module, and Apache Wicket.
-		</p>
-		Phases: Implementation; Architecture and Design
-		<p>
-		Understand the context in which your data will be used and the encoding that will be expected. This is especially important when transmitting data between different components, or when generating outputs that can contain multiple encodings at the same time, such as web pages or multi-part mail messages. Study all expected communication protocols and data representations to determine the required encoding strategies.
-		For any data that will be output to another web page, especially any data that was received from external inputs, use the appropriate encoding on all non-alphanumeric characters.
-		Consult the XSS Prevention Cheat Sheet for more details on the types of encoding and escaping that are needed.
-		</p>
-		Phase: Architecture and Design
-		<p>
-		For any security checks that are performed on the client side, ensure that these checks are duplicated on the server side, in order to avoid CWE-602. Attackers can bypass the client-side checks by modifying values after the checks have been performed, or by changing the client to remove the client-side checks entirely. Then, these modified values would be submitted to the server.
-		If available, use structured mechanisms that automatically enforce the separation between data and code. These mechanisms may be able to provide the relevant quoting, encoding, and validation automatically, instead of relying on the developer to provide this capability at every point where output is generated.
-		</p>
-		Phase: Implementation
-		<p>
-		For every web page that is generated, use and specify a character encoding such as ISO-8859-1 or UTF-8. When an encoding is not specified, the web browser may choose a different encoding by guessing which encoding is actually being used by the web page. This can cause the web browser to treat certain sequences as special, opening up the client to subtle XSS attacks. See CWE-116 for more mitigations related to encoding/escaping.
-		To help mitigate XSS attacks against the user's session cookie, set the session cookie to be HttpOnly. In browsers that support the HttpOnly feature (such as more recent versions of Internet Explorer and Firefox), this attribute can prevent the user's session cookie from being accessible to malicious client-side scripts that use document.cookie. This is not a complete solution, since HttpOnly is not supported by all browsers. More importantly, XMLHTTPRequest and other powerful browser technologies provide read access to HTTP headers, including the Set-Cookie header in which the HttpOnly flag is set.
-		Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use a whitelist of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a blacklist). However, blacklists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
-		When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
-		Ensure that you perform input validation at well-defined interfaces within the application. This will help protect the application even if a component is reused or moved elsewhere.
-		</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="http://projects.webappsec.org/Cross-Site-Scripting">Cross Site Scripting</a></li>
-		<li><a href="http://cwe.mitre.org/data/definitions/79.html">CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')</a></li>
-		</ul>]]>
+    Phase: Architecture and Design
+    <p>
+    Use a vetted library or framework that does not allow this weakness to occur or provides constructs that make this weakness easier to avoid.
+    Examples of libraries and frameworks that make it easier to generate properly encoded output include Microsoft's Anti-XSS library, the OWASP ESAPI Encoding module, and Apache Wicket.
+    </p>
+    Phases: Implementation; Architecture and Design
+    <p>
+    Understand the context in which your data will be used and the encoding that will be expected. This is especially important when transmitting data between different components, or when generating outputs that can contain multiple encodings at the same time, such as web pages or multi-part mail messages. Study all expected communication protocols and data representations to determine the required encoding strategies.
+    For any data that will be output to another web page, especially any data that was received from external inputs, use the appropriate encoding on all non-alphanumeric characters.
+    Consult the XSS Prevention Cheat Sheet for more details on the types of encoding and escaping that are needed.
+    </p>
+    Phase: Architecture and Design
+    <p>
+    For any security checks that are performed on the client side, ensure that these checks are duplicated on the server side, in order to avoid CWE-602. Attackers can bypass the client-side checks by modifying values after the checks have been performed, or by changing the client to remove the client-side checks entirely. Then, these modified values would be submitted to the server.
+    If available, use structured mechanisms that automatically enforce the separation between data and code. These mechanisms may be able to provide the relevant quoting, encoding, and validation automatically, instead of relying on the developer to provide this capability at every point where output is generated.
+    </p>
+    Phase: Implementation
+    <p>
+    For every web page that is generated, use and specify a character encoding such as ISO-8859-1 or UTF-8. When an encoding is not specified, the web browser may choose a different encoding by guessing which encoding is actually being used by the web page. This can cause the web browser to treat certain sequences as special, opening up the client to subtle XSS attacks. See CWE-116 for more mitigations related to encoding/escaping.
+    To help mitigate XSS attacks against the user's session cookie, set the session cookie to be HttpOnly. In browsers that support the HttpOnly feature (such as more recent versions of Internet Explorer and Firefox), this attribute can prevent the user's session cookie from being accessible to malicious client-side scripts that use document.cookie. This is not a complete solution, since HttpOnly is not supported by all browsers. More importantly, XMLHTTPRequest and other powerful browser technologies provide read access to HTTP headers, including the Set-Cookie header in which the HttpOnly flag is set.
+    Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use a whitelist of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a blacklist). However, blacklists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
+    When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
+    Ensure that you perform input validation at well-defined interfaces within the application. This will help protect the application even if a component is reused or moved elsewhere.
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="http://projects.webappsec.org/Cross-Site-Scripting">Cross Site Scripting</a></li>
+    <li><a href="http://cwe.mitre.org/data/definitions/79.html">CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')</a></li>
+    </ul>]]>
         </description>
         <severity>CRITICAL</severity>
         <status>READY</status>
@@ -577,35 +722,35 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		Phase: Architecture and Design
-		<p>
-		Use a vetted library or framework that does not allow this weakness to occur or provides constructs that make this weakness easier to avoid.
-		Examples of libraries and frameworks that make it easier to generate properly encoded output include Microsoft's Anti-XSS library, the OWASP ESAPI Encoding module, and Apache Wicket.
-		</p>
-		Phases: Implementation; Architecture and Design
-		<p>
-		Understand the context in which your data will be used and the encoding that will be expected. This is especially important when transmitting data between different components, or when generating outputs that can contain multiple encodings at the same time, such as web pages or multi-part mail messages. Study all expected communication protocols and data representations to determine the required encoding strategies.
-		For any data that will be output to another web page, especially any data that was received from external inputs, use the appropriate encoding on all non-alphanumeric characters.
-		Consult the XSS Prevention Cheat Sheet for more details on the types of encoding and escaping that are needed.
-		</p>
-		Phase: Architecture and Design
-		<p>
-		For any security checks that are performed on the client side, ensure that these checks are duplicated on the server side, in order to avoid CWE-602. Attackers can bypass the client-side checks by modifying values after the checks have been performed, or by changing the client to remove the client-side checks entirely. Then, these modified values would be submitted to the server.
-		If available, use structured mechanisms that automatically enforce the separation between data and code. These mechanisms may be able to provide the relevant quoting, encoding, and validation automatically, instead of relying on the developer to provide this capability at every point where output is generated.
-		</p>
-		Phase: Implementation
-		<p>
-		For every web page that is generated, use and specify a character encoding such as ISO-8859-1 or UTF-8. When an encoding is not specified, the web browser may choose a different encoding by guessing which encoding is actually being used by the web page. This can cause the web browser to treat certain sequences as special, opening up the client to subtle XSS attacks. See CWE-116 for more mitigations related to encoding/escaping.
-		To help mitigate XSS attacks against the user's session cookie, set the session cookie to be HttpOnly. In browsers that support the HttpOnly feature (such as more recent versions of Internet Explorer and Firefox), this attribute can prevent the user's session cookie from being accessible to malicious client-side scripts that use document.cookie. This is not a complete solution, since HttpOnly is not supported by all browsers. More importantly, XMLHTTPRequest and other powerful browser technologies provide read access to HTTP headers, including the Set-Cookie header in which the HttpOnly flag is set.
-		Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use a whitelist of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a blacklist). However, blacklists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
-		When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
-		Ensure that you perform input validation at well-defined interfaces within the application. This will help protect the application even if a component is reused or moved elsewhere.
-		</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="http://projects.webappsec.org/Cross-Site-Scripting">Cross Site Scripting</a></li>
-		<li><a href="http://cwe.mitre.org/data/definitions/79.html">CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')</a></li>
-		</ul>]]>
+    Phase: Architecture and Design
+    <p>
+    Use a vetted library or framework that does not allow this weakness to occur or provides constructs that make this weakness easier to avoid.
+    Examples of libraries and frameworks that make it easier to generate properly encoded output include Microsoft's Anti-XSS library, the OWASP ESAPI Encoding module, and Apache Wicket.
+    </p>
+    Phases: Implementation; Architecture and Design
+    <p>
+    Understand the context in which your data will be used and the encoding that will be expected. This is especially important when transmitting data between different components, or when generating outputs that can contain multiple encodings at the same time, such as web pages or multi-part mail messages. Study all expected communication protocols and data representations to determine the required encoding strategies.
+    For any data that will be output to another web page, especially any data that was received from external inputs, use the appropriate encoding on all non-alphanumeric characters.
+    Consult the XSS Prevention Cheat Sheet for more details on the types of encoding and escaping that are needed.
+    </p>
+    Phase: Architecture and Design
+    <p>
+    For any security checks that are performed on the client side, ensure that these checks are duplicated on the server side, in order to avoid CWE-602. Attackers can bypass the client-side checks by modifying values after the checks have been performed, or by changing the client to remove the client-side checks entirely. Then, these modified values would be submitted to the server.
+    If available, use structured mechanisms that automatically enforce the separation between data and code. These mechanisms may be able to provide the relevant quoting, encoding, and validation automatically, instead of relying on the developer to provide this capability at every point where output is generated.
+    </p>
+    Phase: Implementation
+    <p>
+    For every web page that is generated, use and specify a character encoding such as ISO-8859-1 or UTF-8. When an encoding is not specified, the web browser may choose a different encoding by guessing which encoding is actually being used by the web page. This can cause the web browser to treat certain sequences as special, opening up the client to subtle XSS attacks. See CWE-116 for more mitigations related to encoding/escaping.
+    To help mitigate XSS attacks against the user's session cookie, set the session cookie to be HttpOnly. In browsers that support the HttpOnly feature (such as more recent versions of Internet Explorer and Firefox), this attribute can prevent the user's session cookie from being accessible to malicious client-side scripts that use document.cookie. This is not a complete solution, since HttpOnly is not supported by all browsers. More importantly, XMLHTTPRequest and other powerful browser technologies provide read access to HTTP headers, including the Set-Cookie header in which the HttpOnly flag is set.
+    Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use a whitelist of acceptable inputs that strictly conform to specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for malicious or malformed inputs (i.e., do not rely on a blacklist). However, blacklists can be useful for detecting potential attacks or determining which inputs are so malformed that they should be rejected outright.
+    When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
+    Ensure that you perform input validation at well-defined interfaces within the application. This will help protect the application even if a component is reused or moved elsewhere.
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="http://projects.webappsec.org/Cross-Site-Scripting">Cross Site Scripting</a></li>
+    <li><a href="http://cwe.mitre.org/data/definitions/79.html">CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')</a></li>
+    </ul>]]>
         </description>
         <severity>CRITICAL</severity>
         <status>READY</status>
@@ -620,11 +765,11 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>N/A</p>
-		<h3>References:</h3>
-		<ul>
-		<li>No reference.</li>
-		</ul>]]>
+    <p>N/A</p>
+    <h3>References:</h3>
+    <ul>
+    <li>No reference.</li>
+    </ul>]]>
         </description>
         <severity>INFO</severity>
         <status>READY</status>
@@ -639,11 +784,11 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>N/A</p>
-		<h3>References:</h3>
-		<ul>
-		<li>No reference.</li>
-		</ul>]]>
+    <p>N/A</p>
+    <h3>References:</h3>
+    <ul>
+    <li>No reference.</li>
+    </ul>]]>
         </description>
         <severity>INFO</severity>
         <status>READY</status>
@@ -658,23 +803,23 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Do not trust client side input, even if there is client side validation in place. In general, type check all data on the server side.</br>
-		If the application uses JDBC, use PreparedStatement or CallableStatement, with parameters passed by '?'</br>
-		If the application uses ASP, use ADO Command Objects with strong type checking and parameterized queries.</br>
-		If database Stored Procedures can be used, use them.</br>
-		Do *not* concatenate strings into queries in the stored procedure, or use 'exec', 'exec immediate', or equivalent functionality!</br>
-		Do not create dynamic SQL queries using simple string concatenation.</br>
-		Escape all data received from the client.</br>
-		Apply a 'whitelist' of allowed characters, or a 'blacklist' of disallowed characters in user input.</br>
-		Apply the privilege of least privilege by using the least privileged database user possible.</br>
-		In particular, avoid using the 'sa' or 'db-owner' database users. This does not eliminate SQL injection, but minimizes its impact.</br>
-		Grant the minimum database access that is necessary for the application.
-		</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="https://www.owasp.org/index.php/Top_10_2010-A1">Top 10 2010-A1-Injection</a></li>
-		<li><a href="https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet">SQL Injection Prevention Cheat Sheet</a></li>
-		</ul>]]>
+    <p>Do not trust client side input, even if there is client side validation in place. In general, type check all data on the server side.</br>
+    If the application uses JDBC, use PreparedStatement or CallableStatement, with parameters passed by '?'</br>
+    If the application uses ASP, use ADO Command Objects with strong type checking and parameterized queries.</br>
+    If database Stored Procedures can be used, use them.</br>
+    Do *not* concatenate strings into queries in the stored procedure, or use 'exec', 'exec immediate', or equivalent functionality!</br>
+    Do not create dynamic SQL queries using simple string concatenation.</br>
+    Escape all data received from the client.</br>
+    Apply a 'whitelist' of allowed characters, or a 'blacklist' of disallowed characters in user input.</br>
+    Apply the privilege of least privilege by using the least privileged database user possible.</br>
+    In particular, avoid using the 'sa' or 'db-owner' database users. This does not eliminate SQL injection, but minimizes its impact.</br>
+    Grant the minimum database access that is necessary for the application.
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="https://www.owasp.org/index.php/Top_10_2010-A1">Top 10 2010-A1-Injection</a></li>
+    <li><a href="https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet">SQL Injection Prevention Cheat Sheet</a></li>
+    </ul>]]>
         </description>
         <severity>CRITICAL</severity>
         <status>READY</status>
@@ -684,20 +829,80 @@ If you want to add a rule, you can, following the model above.
         <tag>zaproxy</tag>
     </rule>
     <rule>
+        <key>50001</key>
+        <name>Script Passive Scan Rules</name>
+
+        <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
+            <![CDATA[<h3>Solution :</h3>
+    <p>
+    N/A
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li>No reference</li>
+    </ul>]]>
+        </description>
+        <severity>CRITICAL</severity>
+        <status>READY</status>
+        <tag>wascid-19</tag>
+        <tag>cweid-89</tag>
+        <tag>security</tag>
+        <tag>zaproxy</tag>
+    </rule>
+    <rule>
+        <key>90001</key>
+        <name>Insecure JSF ViewState</name>
+
+        <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
+            <![CDATA[<h3>Solution :</h3>
+    <p>Protect the ViewState value.
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li>No reference</li>
+    </ul>]]>
+        </description>
+        <severity>MINOR</severity>
+        <status>READY</status>
+        <tag>security</tag>
+        <tag>zaproxy</tag>
+    </rule>
+    <rule>
+        <key>90011</key>
+        <name>Charset Mismatch</name>
+
+        <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
+            <![CDATA[<h3>Solution :</h3>
+    <p>The declaration in the HTTP Content-Type header doesn't match what is declared in a META Content-Type tag, or
+    the declaration in the HTTP Content-Type header doesn't match what is declared in a META Charset tag. Another possibility is that
+    the response doesn't contain a META Content-Type declaration, which may overlook older clients. Correct the declarations.
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="http://www.w3.org/TR/html401/charset.html#h-5.2.2">Charset</a></li>
+    <li><a href="http://www.w3.org/TR/html5/document-metadata.html#charset">Document Metadata Charset</a></li>
+    </ul>]]>
+        </description>
+        <severity>MINOR</severity>
+        <status>READY</status>
+        <tag>security</tag>
+        <tag>zaproxy</tag>
+    </rule>
+    <rule>
         <key>90019</key>
         <name>Server Side Code Injection</name>
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>Do not trust client side input, even if there is client side validation in place. </br>
-		In general, type check all data on the server side and escape all data received from the client.</br>
-		Avoid the use of eval() functions combined with user input data.
-		</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="http://cwe.mitre.org/data/definitions/94.html">CWE-94: Improper Control of Generation of Code ('Code Injection')</a></li>
-		<li><a href="https://www.owasp.org/index.php/Direct_Dynamic_Code_Evaluation_('Eval_Injection')">Direct Dynamic Code Evaluation ('Eval Injection')</a></li>
-		</ul>]]>
+    <p>Do not trust client side input, even if there is client side validation in place. </br>
+    In general, type check all data on the server side and escape all data received from the client.</br>
+    Avoid the use of eval() functions combined with user input data.
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="http://cwe.mitre.org/data/definitions/94.html">CWE-94: Improper Control of Generation of Code ('Code Injection')</a></li>
+    <li><a href="https://www.owasp.org/index.php/Direct_Dynamic_Code_Evaluation_('Eval_Injection')">Direct Dynamic Code Evaluation ('Eval Injection')</a></li>
+    </ul>]]>
         </description>
         <severity>CRITICAL</severity>
         <status>READY</status>
@@ -711,68 +916,68 @@ If you want to add a rule, you can, following the model above.
 
         <description> <!-- Corresponding to "<solution>" and "<reference>" of the ZAP report -->
             <![CDATA[<h3>Solution :</h3>
-		<p>If at all possible, use library calls rather than external processes to recreate the desired functionality.
-		Run your code in a "jail" or similar sandbox environment that enforces strict boundaries between the process and the operating system. This may effectively restrict
-		which files can be accessed in a particular directory or which commands can be executed by your software.
+    <p>If at all possible, use library calls rather than external processes to recreate the desired functionality.
+    Run your code in a "jail" or similar sandbox environment that enforces strict boundaries between the process and the operating system. This may effectively restrict
+    which files can be accessed in a particular directory or which commands can be executed by your software.
 
-		OS-level examples include the Unix chroot jail, AppArmor, and SELinux. In general, managed code may provide some protection. For example, java.io.FilePermission in
-		the Java SecurityManager allows you to specify restrictions on file operations.
-		This may not be a feasible solution, and it only limits the impact to the operating system; the rest of your application may still be subject to compromise.
+    OS-level examples include the Unix chroot jail, AppArmor, and SELinux. In general, managed code may provide some protection. For example, java.io.FilePermission in
+    the Java SecurityManager allows you to specify restrictions on file operations.
+    This may not be a feasible solution, and it only limits the impact to the operating system; the rest of your application may still be subject to compromise.
 
-		For any data that will be used to generate a command to be executed, keep as much of that data out of external control as possible. For example, in web applications,
-		this may require storing the command locally in the session's state instead of sending it out to the client in a hidden form field.
+    For any data that will be used to generate a command to be executed, keep as much of that data out of external control as possible. For example, in web applications,
+    this may require storing the command locally in the session's state instead of sending it out to the client in a hidden form field.
 
-		Use a vetted library or framework that does not allow this weakness to occur or provides constructs that make this weakness easier to avoid.
+    Use a vetted library or framework that does not allow this weakness to occur or provides constructs that make this weakness easier to avoid.
 
-		For example, consider using the ESAPI Encoding control or a similar tool, library, or framework. These will help the programmer encode outputs in a manner less
-		prone to error.
+    For example, consider using the ESAPI Encoding control or a similar tool, library, or framework. These will help the programmer encode outputs in a manner less
+    prone to error.
 
-		If you need to use dynamically-generated query strings or commands in spite of the risk, properly quote arguments and escape any special characters within those
-		arguments. The most conservative approach is to escape or filter all characters that do not pass an extremely strict whitelist (such as everything that is not
-		alphanumeric or white space). If some special characters are still needed, such as white space, wrap each argument in quotes after the escaping/filtering step. Be
-		careful of argument injection.
+    If you need to use dynamically-generated query strings or commands in spite of the risk, properly quote arguments and escape any special characters within those
+    arguments. The most conservative approach is to escape or filter all characters that do not pass an extremely strict whitelist (such as everything that is not
+    alphanumeric or white space). If some special characters are still needed, such as white space, wrap each argument in quotes after the escaping/filtering step. Be
+    careful of argument injection.
 
-		If the program to be executed allows arguments to be specified within an input file or from standard input, then consider using that mode to pass arguments instead
-		of the command line.
+    If the program to be executed allows arguments to be specified within an input file or from standard input, then consider using that mode to pass arguments instead
+    of the command line.
 
-		If available, use structured mechanisms that automatically enforce the separation between data and code. These mechanisms may be able to provide the relevant
-		quoting, encoding, and validation automatically, instead of relying on the developer to provide this capability at every point where output is generated.
+    If available, use structured mechanisms that automatically enforce the separation between data and code. These mechanisms may be able to provide the relevant
+    quoting, encoding, and validation automatically, instead of relying on the developer to provide this capability at every point where output is generated.
 
-		Some languages offer multiple functions that can be used to invoke commands. Where possible, identify any function that invokes a command shell using a single
-		string, and replace it with a function that requires individual arguments. These functions typically perform appropriate quoting and filtering of arguments. For
-		example, in C, the system() function accepts a string that contains the entire command to be executed, whereas execl(), execve(), and others require an array of
-		strings, one for each argument. In Windows, CreateProcess() only accepts one command at a time. In Perl, if system() is provided with an array of arguments, then
-		it will quote each of the arguments.
+    Some languages offer multiple functions that can be used to invoke commands. Where possible, identify any function that invokes a command shell using a single
+    string, and replace it with a function that requires individual arguments. These functions typically perform appropriate quoting and filtering of arguments. For
+    example, in C, the system() function accepts a string that contains the entire command to be executed, whereas execl(), execve(), and others require an array of
+    strings, one for each argument. In Windows, CreateProcess() only accepts one command at a time. In Perl, if system() is provided with an array of arguments, then
+    it will quote each of the arguments.
 
-		Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use a whitelist of acceptable inputs that strictly conform to
-		specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for
-		malicious or malformed inputs (i.e., do not rely on a blacklist). However, blacklists can be useful for detecting potential attacks or determining which inputs are
-		so malformed that they should be rejected outright.
+    Assume all input is malicious. Use an "accept known good" input validation strategy, i.e., use a whitelist of acceptable inputs that strictly conform to
+    specifications. Reject any input that does not strictly conform to specifications, or transform it into something that does. Do not rely exclusively on looking for
+    malicious or malformed inputs (i.e., do not rely on a blacklist). However, blacklists can be useful for detecting potential attacks or determining which inputs are
+    so malformed that they should be rejected outright.
 
-		When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or
-		extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid
-		because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
+    When performing input validation, consider all potentially relevant properties, including length, type of input, the full range of acceptable values, missing or
+    extra inputs, syntax, consistency across related fields, and conformance to business rules. As an example of business rule logic, "boat" may be syntactically valid
+    because it only contains alphanumeric characters, but it is not valid if you are expecting colors such as "red" or "blue."
 
-		When constructing OS command strings, use stringent whitelists that limit the character set based on the expected value of the parameter in the request. This will
-		indirectly limit the scope of an attack, but this technique is less important than proper output encoding and escaping.
+    When constructing OS command strings, use stringent whitelists that limit the character set based on the expected value of the parameter in the request. This will
+    indirectly limit the scope of an attack, but this technique is less important than proper output encoding and escaping.
 
-		Note that proper output encoding, escaping, and quoting is the most effective solution for preventing OS command injection, although input validation may provide
-		some defense-in-depth. This is because it effectively limits what will appear in output. Input validation will not always prevent OS command injection, especially
-		if you are required to support free-form text fields that could contain arbitrary characters. For example, when invoking a mail program, you might need to allow the
-		subject field to contain otherwise-dangerous inputs like ";" and ">" characters, which would need to be escaped or otherwise handled. In this case, stripping the
-		character might reduce the risk of OS command injection, but it would produce incorrect behavior because the subject field would not be recorded as the user
-		intended. This might seem to be a minor inconvenience, but it could be more important when the program relies on well-structured subject lines in order to pass
-		messages to other components.
+    Note that proper output encoding, escaping, and quoting is the most effective solution for preventing OS command injection, although input validation may provide
+    some defense-in-depth. This is because it effectively limits what will appear in output. Input validation will not always prevent OS command injection, especially
+    if you are required to support free-form text fields that could contain arbitrary characters. For example, when invoking a mail program, you might need to allow the
+    subject field to contain otherwise-dangerous inputs like ";" and ">" characters, which would need to be escaped or otherwise handled. In this case, stripping the
+    character might reduce the risk of OS command injection, but it would produce incorrect behavior because the subject field would not be recorded as the user
+    intended. This might seem to be a minor inconvenience, but it could be more important when the program relies on well-structured subject lines in order to pass
+    messages to other components.
 
-		Even if you make a mistake in your validation (such as forgetting one out of 100 input fields), appropriate encoding is still likely to protect you from
-		injection-based attacks. As long as it is not done in isolation, input validation is still a useful technique, since it may significantly reduce your attack
-		surface, allow you to detect some attacks, and provide other security benefits that proper encoding does not address.</solution>
-		</p>
-		<h3>References:</h3>
-		<ul>
-		<li><a href="http://cwe.mitre.org/data/definitions/78.html">CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')</a></li>
-		<li><a href="https://www.owasp.org/index.php/Command_Injection">Command Injection</a></li>
-		</ul>]]>
+    Even if you make a mistake in your validation (such as forgetting one out of 100 input fields), appropriate encoding is still likely to protect you from
+    injection-based attacks. As long as it is not done in isolation, input validation is still a useful technique, since it may significantly reduce your attack
+    surface, allow you to detect some attacks, and provide other security benefits that proper encoding does not address.</solution>
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li><a href="http://cwe.mitre.org/data/definitions/78.html">CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')</a></li>
+    <li><a href="https://www.owasp.org/index.php/Command_Injection">Command Injection</a></li>
+    </ul>]]>
         </description>
         <severity>CRITICAL</severity>
         <status>READY</status>
@@ -786,12 +991,12 @@ If you want to add a rule, you can, following the model above.
         <name>Application Error Disclosure</name>
         <description>
             <![CDATA[<h3>Solution :</h3>
-		<p>Review the source code of this page. Implement custom error pages. Consider implementing a mechanism to provide a unique error reference/identifier to
-		the client (browser) while logging the details on the server side and not exposing them to the user.</p>
-		<h3>References:</h3>
-		<ul>
-		<li>No Reference.</li>
-		</ul>]]>
+    <p>Review the source code of this page. Implement custom error pages. Consider implementing a mechanism to provide a unique error reference/identifier to
+    the client (browser) while logging the details on the server side and not exposing them to the user.</p>
+    <h3>References:</h3>
+    <ul>
+    <li>No Reference.</li>
+    </ul>]]>
         </description>
         <severity>MAJOR</severity>
         <status>READY</status>
@@ -799,5 +1004,44 @@ If you want to add a rule, you can, following the model above.
         <tag>cweid-200</tag>
         <tag>security</tag>
         <tag>zaproxy</tag>
+    </rule>
+    <rule>
+        <key>90030</key>
+        <name>WSDL File Passive Scanner</name>
+        <description>
+            <![CDATA[<h3>Solution :</h3>
+    <p>
+    N/A
+    </p>
+    <h3>References:</h3>
+    <ul>
+    <li>No Reference.</li>
+    </ul>]]>
+        </description>
+        <severity>MINOR</severity>
+        <status>READY</status>
+        <tag>security</tag>
+        <tag>zaproxy</tag>
+    </rule>
+    <rule>
+        <key>90033</key>
+        <name>Loosely Scoped Cookie</name>
+        <description>
+            <![CDATA[<h3>Solution :</h3>
+    <p>Always scope cookies to a FQDN (Fully Qualified Domain Name).</p>
+    N/A
+    <h3>References:</h3>
+    <ul>
+    <li><a href="https://tools.ietf.org/html/rfc6265#section-4.1/></li>
+    <li><a href="https://www.owasp.org/index.php/Testing_for_cookies_attributes_(OTG-SESS-002)/></li>
+    <li><a href="http://code.google.com/p/browsersec/wiki/Part2#Same-origin_policy_for_cookies/></li>
+    </ul>]]>
+        </description>
+        <severity>INFO</severity>
+        <status>READY</status>
+        <tag>security</tag>
+        <tag>zaproxy</tag>
+        <tag>wascid-15</tag>
+        <tag>cweid-565</tag>
     </rule>
 </rules>

--- a/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/parser/ReportParserTest.java
+++ b/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/parser/ReportParserTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 
 import org.junit.Test;
 import org.sonar.zaproxy.parser.element.AlertItem;
-import org.sonar.zaproxy.parser.element.Instance;
 import org.sonar.zaproxy.parser.element.Site;
 import org.sonar.zaproxy.parser.element.ZapReport;
 

--- a/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/parser/ReportParserTest.java
+++ b/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/parser/ReportParserTest.java
@@ -24,9 +24,11 @@ import static org.fest.assertions.Assertions.assertThat;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 
 import org.junit.Test;
 import org.sonar.zaproxy.parser.element.AlertItem;
+import org.sonar.zaproxy.parser.element.Instance;
 import org.sonar.zaproxy.parser.element.Site;
 import org.sonar.zaproxy.parser.element.ZapReport;
 
@@ -37,35 +39,42 @@ public class ReportParserTest {
         ReportParser parser = new ReportParser();
         InputStream inputStream = getClass().getClassLoader().getResourceAsStream("report/zaproxy-report.xml");
         ZapReport zapReport = parser.parse(inputStream);
-        assertThat(zapReport.getGenerated()).isEqualTo("jeu., 7 mai 2015 16:14:12");
-        assertThat(zapReport.getVersionZAP()).isEqualTo("2.4.0");
+        assertThat(zapReport.getGenerated()).isEqualTo("Thu, 3 May 2018 06:15:48");
+        assertThat(zapReport.getVersionZAP()).isEqualTo("D-2018-03-26");
 
-        Site site = zapReport.getSite();
-        assertThat(site.getHost()).isEqualTo("localhost");
-        assertThat(site.getName()).isEqualTo("http://localhost:8180");
-        assertThat(site.getPort()).isEqualTo(8180);
+        List<Site> sites = zapReport.getSites();
+        Site site = sites.get(0);
+        assertThat(site.getHost()).isEqualTo("example.org");
+        assertThat(site.getName()).isEqualTo("http://example.org");
+        assertThat(site.getPort()).isEqualTo(80);
         assertThat(site.isSsl()).isEqualTo(false);
 
         Collection<AlertItem> alerts = site.getAlerts();
-        assertThat(alerts.size()).isEqualTo(236);
+        assertThat(alerts.size()).isEqualTo(1);
 
         Iterator<AlertItem> iterator = alerts.iterator();
         AlertItem alert = iterator.next();
 
-        assertThat(alert.getPluginid()).isEqualTo(10016);
-        assertThat(alert.getAlert()).isEqualTo("Web Browser XSS Protection Not Enabled");
+        assertThat(alert.getPluginid()).isEqualTo(10010);
+        assertThat(alert.getAlert()).isEqualTo("Cookie No HttpOnly Flag");
         assertThat(alert.getRiskcode()).isEqualTo(1);
         assertThat(alert.getConfidence()).isEqualTo(2);
         assertThat(alert.getRiskdesc()).isEqualTo("Low (Medium)");
-        assertThat(alert.getDesc()).isEqualTo("Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server");
-        assertThat(alert.getUri()).isEqualTo("http://localhost:8180/robots.txt");
-        assertThat(alert.getParam()).isNullOrEmpty();
+        assertThat(alert.getDesc()).isEqualTo("<p>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.</p>");
+        assertThat(alert.getInstances().size()).isEqualTo(20);
+        assertThat(alert.getInstances().get(1).getUri()).isEqualTo("http://example.org/support");
+        assertThat(alert.getInstances().get(1).getMethod()).isEqualTo("GET");
+        assertThat(alert.getInstances().get(1).getParam()).isEqualTo("_pxCaptcha");
+        assertThat(alert.getInstances().get(1).getEvidence()).isEqualTo("Set-Cookie: _pxCaptcha");
+
+//        assertThat(alert.getUri()).isEqualTo("http://localhost:8180/robots.txt");
+//        assertThat(alert.getParam()).isNullOrEmpty();
         assertThat(alert.getAttack()).isNullOrEmpty();
-        assertThat(alert.getOtherinfo()).endsWith("Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).");
-        assertThat(alert.getSolution()).isEqualTo("Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.");
-        assertThat(alert.getReference()).contains("https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet");
-        assertThat(alert.getCweid()).isEqualTo(933);
-        assertThat(alert.getWascid()).isEqualTo(14);
+        //assertThat(alert.getOtherinfo()).endsWith("Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).");
+        assertThat(alert.getSolution()).isEqualTo("<p>Ensure that the HttpOnly flag is set for all cookies.</p>");
+        assertThat(alert.getReference()).contains("<p>http://www.owasp.org/index.php/HttpOnly</p>");
+        assertThat(alert.getCweid()).isEqualTo(16);
+        assertThat(alert.getWascid()).isEqualTo(13);
     }
 
 }

--- a/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/parser/ReportParserTest.java
+++ b/sonar-zap-plugin/src/test/java/org/sonar/zaproxy/parser/ReportParserTest.java
@@ -76,4 +76,44 @@ public class ReportParserTest {
         assertThat(alert.getWascid()).isEqualTo(13);
     }
 
+    @Test
+    public void parseReportNoInstances() throws Exception {
+        ReportParser parser = new ReportParser();
+        InputStream inputStream = getClass().getClassLoader().getResourceAsStream("report/zaproxy-report-no-instances.xml");
+        ZapReport zapReport = parser.parse(inputStream);
+        assertThat(zapReport.getGenerated()).isEqualTo("Fri, 8 Jun 2018 09:55:08");
+        assertThat(zapReport.getVersionZAP()).isEqualTo("2.7.0");
+
+        List<Site> sites = zapReport.getSites();
+        Site site = sites.get(0);
+        assertThat(site.getHost()).isEqualTo("example.org");
+        assertThat(site.getName()).isEqualTo("http://example.org");
+        assertThat(site.getPort()).isEqualTo(80);
+        assertThat(site.isSsl()).isEqualTo(false);
+
+        Collection<AlertItem> alerts = site.getAlerts();
+        assertThat(alerts.size()).isEqualTo(3);
+
+        Iterator<AlertItem> iterator = alerts.iterator();
+        AlertItem alert = iterator.next();
+
+        assertThat(alert.getPluginid()).isEqualTo(10015);
+        assertThat(alert.getAlert()).isEqualTo("Incomplete or No Cache-control and Pragma HTTP Header Set");
+        assertThat(alert.getRiskcode()).isEqualTo(1);
+        assertThat(alert.getConfidence()).isEqualTo(2);
+        assertThat(alert.getRiskdesc()).isEqualTo("Low (Medium)");
+        assertThat(alert.getDesc()).isEqualTo("<p>The cache-control and pragma HTTP header have not been set properly or are missing allowing the browser and proxies to cache content.</p>");
+        assertThat(alert.getInstances()).isNull();
+        assertThat(alert.getUri()).isEqualTo("http://example.org/sites/example.org/files/advagg_css/css.css");
+        assertThat(alert.getMethod()).isEqualTo("GET");
+        assertThat(alert.getParam()).isEqualTo("Cache-Control");
+        assertThat(alert.getEvidence()).isEqualTo("max-age=31449600, no-transform, public");
+
+        assertThat(alert.getAttack()).isNullOrEmpty();
+
+        assertThat(alert.getSolution()).isEqualTo("<p>Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate; and that the pragma HTTP header is set with no-cache.</p>");
+        assertThat(alert.getReference()).contains("<p>https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Web_Content_Caching</p>");
+        assertThat(alert.getCweid()).isEqualTo(525);
+        assertThat(alert.getWascid()).isEqualTo(13);
+    }
 }

--- a/sonar-zap-plugin/src/test/resources/report/zaproxy-report-no-instances.xml
+++ b/sonar-zap-plugin/src/test/resources/report/zaproxy-report-no-instances.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?><OWASPZAPReport version="2.7.0" generated="Fri, 8 Jun 2018 09:55:08">
+<site name="http://example.org" host="example.org" port="80" ssl="false"><alerts><alertitem>
+  <pluginid>10015</pluginid>
+  <alert>Incomplete or No Cache-control and Pragma HTTP Header Set</alert>
+  <name>Incomplete or No Cache-control and Pragma HTTP Header Set</name>
+  <riskcode>1</riskcode>
+  <confidence>2</confidence>
+  <riskdesc>Low (Medium)</riskdesc>
+  <desc>&lt;p&gt;The cache-control and pragma HTTP header have not been set properly or are missing allowing the browser and proxies to cache content.&lt;/p&gt;</desc>
+  <uri>http://example.org/sites/example.org/files/advagg_css/css.css</uri>
+  <method>GET</method>
+  <param>Cache-Control</param>
+  <evidence>max-age=31449600, no-transform, public</evidence>
+  <solution>&lt;p&gt;Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate; and that the pragma HTTP header is set with no-cache.&lt;/p&gt;</solution>
+  <reference>&lt;p&gt;https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Web_Content_Caching&lt;/p&gt;</reference>
+  <cweid>525</cweid>
+  <wascid>13</wascid>
+  <sourceid>3</sourceid>
+</alertitem>
+<alertitem>
+  <pluginid>10015</pluginid>
+  <alert>Incomplete or No Cache-control and Pragma HTTP Header Set</alert>
+  <name>Incomplete or No Cache-control and Pragma HTTP Header Set</name>
+  <riskcode>1</riskcode>
+  <confidence>2</confidence>
+  <riskdesc>Low (Medium)</riskdesc>
+  <desc>&lt;p&gt;The cache-control and pragma HTTP header have not been set properly or are missing allowing the browser and proxies to cache content.&lt;/p&gt;</desc>
+  <uri>http://example.org/sites/example.org/files/advagg_css/css.css</uri>
+  <method>GET</method>
+  <param>Cache-Control</param>
+  <evidence>max-age=31449600, no-transform, public</evidence>
+  <solution>&lt;p&gt;Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate; and that the pragma HTTP header is set with no-cache.&lt;/p&gt;</solution>
+  <reference>&lt;p&gt;https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Web_Content_Caching&lt;/p&gt;</reference>
+  <cweid>525</cweid>
+  <wascid>13</wascid>
+  <sourceid>3</sourceid>
+</alertitem>
+<alertitem>
+  <pluginid>10011</pluginid>
+  <alert>Cookie Without Secure Flag</alert>
+  <name>Cookie Without Secure Flag</name>
+  <riskcode>1</riskcode>
+  <confidence>2</confidence>
+  <riskdesc>Low (Medium)</riskdesc>
+  <desc>&lt;p&gt;A cookie has been set without the secure flag, which means that the cookie can be accessed via unencrypted connections.&lt;/p&gt;</desc>
+  <uri>http://example.org/search?keys=ZAP</uri>
+  <method>GET</method>
+  <param>SESSd6efc89e4c22b4073e93ffa99cc63ba7</param>
+  <evidence>Set-Cookie: SESSd6efc89e4c22b4073e93ffa99cc63ba7</evidence>
+  <solution>&lt;p&gt;Whenever a cookie contains sensitive information or is a session token, then it should always be passed using an encrypted channel. Ensure that the secure flag is set for cookies containing such sensitive information.&lt;/p&gt;</solution>
+  <reference>&lt;p&gt;http://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)&lt;/p&gt;</reference>
+  <cweid>614</cweid>
+  <wascid>13</wascid>
+  <sourceid>3</sourceid>
+</alertitem>
+</alerts></site></OWASPZAPReport>

--- a/sonar-zap-plugin/src/test/resources/report/zaproxy-report.xml
+++ b/sonar-zap-plugin/src/test/resources/report/zaproxy-report.xml
@@ -1,5487 +1,714 @@
-<?xml version="1.0" encoding="UTF-8"?><OWASPZAPReport generated="jeu., 7 mai 2015 16:14:12" version="2.4.0">
-    <site host="localhost" name="http://localhost:8180" port="8180" ssl="false"><alerts><alertitem>
-        <pluginid>10016</pluginid>
-        <alert>Web Browser XSS Protection Not Enabled</alert>
+<?xml version="1.0"?><OWASPZAPReport version="D-2018-03-26" generated="Thu, 3 May 2018 06:15:48">
+    <site name="http://example.org" host="example.org" port="80" ssl="false"><alerts><alertitem>
+        <pluginid>10010</pluginid>
+        <alert>Cookie No HttpOnly Flag</alert>
+        <name>Cookie No HttpOnly Flag</name>
         <riskcode>1</riskcode>
         <confidence>2</confidence>
         <riskdesc>Low (Medium)</riskdesc>
-        <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-        </desc>
-        <uri>http://localhost:8180/robots.txt</uri>
-        <param/>
-        <attack/>
-        <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-            X-XSS-Protection: 1; mode=block
-            X-XSS-Protection: 1; report=http://www.example.com/xss
-            The following values would disable it:
-            X-XSS-Protection: 0
-            The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-            Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-        <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-        </solution>
-        <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-            X-XSS-Protection: 1; mode=block
-            X-XSS-Protection: 1; report=http://www.example.com/xss
-            The following values would disable it:
-            X-XSS-Protection: 0
-            The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-            Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-        </otherinfo>
-        <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-            https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-        </reference>
-        <cweid>933</cweid>
-        <wascid>14</wascid>
+        <desc>&lt;p&gt;A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.&lt;/p&gt;</desc>
+        <instances>
+            <instance>
+                <uri>http://example.org/localize</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/support</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/getting-started/clean-urls</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/security-team</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/node/948216</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/project/drupal</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/update/theme</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/cron,</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/requirements</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/node/3854</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/documentation/theme</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/developing/modules.</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/files/projects/drupal-x.y.tar.gz</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/update/modules</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/security</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/node/157602</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/upgrade/backing-up-the-db</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/getting-started/7/admin</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/project/modules</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+            <instance>
+                <uri>http://example.org/upgrade</uri>
+                <method>GET</method>
+                <param>_pxCaptcha</param>
+                <evidence>Set-Cookie: _pxCaptcha</evidence>
+            </instance>
+        </instances>
+        <count>28</count>
+        <solution>&lt;p&gt;Ensure that the HttpOnly flag is set for all cookies.&lt;/p&gt;</solution>
+        <reference>&lt;p&gt;http://www.owasp.org/index.php/HttpOnly&lt;/p&gt;</reference>
+        <cweid>16</cweid>
+        <wascid>13</wascid>
+        <sourceid>3</sourceid>
     </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/robots.txt</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/robots.txt</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/sitemap.xml</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/sitemap.xml</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/sitemap.xml</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/home.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/home.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/home.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/contact.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/contact.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/contact.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/about.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/about.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/about.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/login.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10012</pluginid>
-            <alert>Password Autocomplete in browser</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>AUTOCOMPLETE attribute is not disabled in HTML FORM/INPUT element containing password type input.  Passwords may be stored in browsers and retrieved.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/login.jsp</uri>
-            <param>input</param>
-            <attack/>
-            <evidence>&lt;input id="password" name="password" type="password"&gt;</evidence>
-            <otherinfo/>
-            <solution>Turn off AUTOCOMPLETE attribute in form or individual input elements containing password by using AUTOCOMPLETE='OFF'
-            </solution>
-            <reference>http://msdn.microsoft.com/library/default.asp?url=/workshop/author/forms/autocomplete_ovr.asp
-            </reference>
-            <cweid>525</cweid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/login.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/login.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/search.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/search.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/search.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=5</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=5</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=5</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48263</param>
-            <attack/>
-            <evidence>b_id=48263</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=3</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=3</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=3</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=2</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=2</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=2</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=6</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=6</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=6</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=7</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=7</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=7</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=4</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=4</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=4</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=23</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=23</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=23</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=1</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=1</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?typeid=1</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=19</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=19</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=19</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=22</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=22</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=22</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=27</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=27</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=27</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=7</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=7</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=7</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=24</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=24</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=24</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=28</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=28</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=28</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=31</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=31</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=31</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=16</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=16</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=16</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=13</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=13</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=13</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=10</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=10</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=10</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=4</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=4</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=4</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=9</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=9</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=9</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=6</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=6</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=6</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=8</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=8</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=8</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/style.css</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/style.css</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/style.css</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/js/util.js</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/js/util.js</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/js/util.js</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=2</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=2</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=2</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/score.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/score.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/score.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/register.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10012</pluginid>
-            <alert>Password Autocomplete in browser</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>AUTOCOMPLETE attribute is not disabled in HTML FORM/INPUT element containing password type input.  Passwords may be stored in browsers and retrieved.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/register.jsp</uri>
-            <param>input</param>
-            <attack/>
-            <evidence>&lt;input id="password1" name="password1" type="password"&gt;</evidence>
-            <otherinfo/>
-            <solution>Turn off AUTOCOMPLETE attribute in form or individual input elements containing password by using AUTOCOMPLETE='OFF'
-            </solution>
-            <reference>http://msdn.microsoft.com/library/default.asp?url=/workshop/author/forms/autocomplete_ovr.asp
-            </reference>
-            <cweid>525</cweid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/register.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/register.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/advanced.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/advanced.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/advanced.jsp</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/search.jsp?q=ZAP</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/search.jsp?q=ZAP</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/search.jsp?q=ZAP</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=25</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=25</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=25</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48264</param>
-            <attack/>
-            <evidence>b_id=48264</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=11</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=11</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=11</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=12</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=12</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=12</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=5</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=5</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=5</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=14</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=14</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=14</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=15</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=15</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=15</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=26</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=26</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=26</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=29</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=29</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=29</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=17</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=17</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=17</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=18</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=18</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=18</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=30</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=30</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=30</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=21</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=21</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=21</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=20</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=20</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=20</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=32</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=32</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=32</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48265</param>
-            <attack/>
-            <evidence>b_id=48265</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=1</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=1</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=1</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10016</pluginid>
-            <alert>Web Browser XSS Protection Not Enabled</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=3</uri>
-            <param/>
-            <attack/>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).</otherinfo>
-            <solution>Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
-            </solution>
-            <otherinfo>The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it:
-                X-XSS-Protection: 1; mode=block
-                X-XSS-Protection: 1; report=http://www.example.com/xss
-                The following values would disable it:
-                X-XSS-Protection: 0
-                The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).
-                Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
-                https://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
-            </reference>
-            <cweid>933</cweid>
-            <wascid>14</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10021</pluginid>
-            <alert>En-tête X-Content-Type-Options manquant</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>L'en-tête X-Content-Type-Options contre le sniffing MIME n'est pas renseigné à 'nosniff'. Ceci permet à de vielles versions d'Internet Explorer et de Chrome de pratiquer le sniffing MIME sur le corps de réponse, conduisant potentiellement à l'interprétation et l'affichage du contenu dans un autre type que celui déclaré. A l'heure actuelle (début 2014), les anciennes versions de Firefox utiliseront le type de contenu déclaré (au cas où un type est déterminé), plutôt qu'analyser le MIME.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=3</uri>
-            <param/>
-            <attack/>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.</otherinfo>
-            <solution>Assurez-vous que l'application ou le serveur internet renseigne l'en-tête Content-Type correctement, et que l'en-tête X-Content-Type-Options prenne la valeur 'nosniff' pour toutes les pages internet.
-                Si possible, assurez-vous que l'utilisateur utilise un navigateur moderne et conforme aux standards, qui ne pratique pas du tout le sniffing MIME, ou qui puisse être commandé par l'application ou le serveur internet de manière à ne pas pratiquer le sniffing MIME.
-            </solution>
-            <otherinfo>Ce problème s'applique toujours aux pages de type erreur (401, 403, 500, etc.), car ces pages sont encore souvent touchées par des problèmes d'injection, auquel cas il est encore possible que les navigateurs interprétent des pages autrement que selon leur type de contenu réel.
-            </otherinfo>
-            <reference>http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx
-                https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-            </reference>
-            <wascid>15</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10020</pluginid>
-            <alert>En-tête X-Frame-Options pas renseigné</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>L'en-tête X-Frame-Options n'est pas incluse dans la réponse HTTP pour protéger contre les attaques de 'ClickJacking'.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/product.jsp?prodid=3</uri>
-            <param/>
-            <attack/>
-            <otherinfo/>
-            <solution>La plupart des navigateurs internet modernes supportent l'en-tête HTTP X-Frame-Options. Assurez-vous que celle-ci est renseignée sur toutes les pages internet retournées par votre site (si cette page ne doit être encadrée que par des pages de votre serveur (p.ex. fait partie d'un FRAMESET), alors utilisez la valeur SAMEORIGIN, sinon choisissez la valeur DENY quand la page n'est jamais encadrée. ALLOW-FROM permet à des sites spécifiques d'encadrer la page, pour autant que le navigateur le supporte).
-            </solution>
-            <reference>http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-            </reference>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48266</param>
-            <attack/>
-            <evidence>b_id=48266</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48268</param>
-            <attack/>
-            <evidence>b_id=48268</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48267</param>
-            <attack/>
-            <evidence>b_id=48267</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48269</param>
-            <attack/>
-            <evidence>b_id=48269</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48270</param>
-            <attack/>
-            <evidence>b_id=48270</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48271</param>
-            <attack/>
-            <evidence>b_id=48271</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48272</param>
-            <attack/>
-            <evidence>b_id=48272</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48273</param>
-            <attack/>
-            <evidence>b_id=48273</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48274</param>
-            <attack/>
-            <evidence>b_id=48274</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48275</param>
-            <attack/>
-            <evidence>b_id=48275</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48276</param>
-            <attack/>
-            <evidence>b_id=48276</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48278</param>
-            <attack/>
-            <evidence>b_id=48278</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48277</param>
-            <attack/>
-            <evidence>b_id=48277</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48279</param>
-            <attack/>
-            <evidence>b_id=48279</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48280</param>
-            <attack/>
-            <evidence>b_id=48280</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>90022</pluginid>
-            <alert>Application Error Disclosure</alert>
-            <riskcode>2</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Medium (Medium)</riskdesc>
-            <desc>This page contains an error/warning message that may disclose sensitive information like the location of the file that produced the unhandled exception. This information can be used to launch further attacks against the web application. The alert could be a false positive if the error message is found inside a documentation page.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/advanced.jsp</uri>
-            <param>N/A</param>
-            <attack/>
-            <evidence>HTTP 500 Internal server error</evidence>
-            <otherinfo/>
-            <solution>Review the source code of this page. Implement custom error pages. Consider implementing a mechanism to provide a unique error reference/identifier to the client (browser) while logging the details on the server side and not exposing them to the user.
-            </solution>
-            <reference>
-            </reference>
-            <cweid>200</cweid>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48281</param>
-            <attack/>
-            <evidence>b_id=48281</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48282</param>
-            <attack/>
-            <evidence>b_id=48282</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48283</param>
-            <attack/>
-            <evidence>b_id=48283</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48285</param>
-            <attack/>
-            <evidence>b_id=48285</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48286</param>
-            <attack/>
-            <evidence>b_id=48286</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48284</param>
-            <attack/>
-            <evidence>b_id=48284</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48287</param>
-            <attack/>
-            <evidence>b_id=48287</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48288</param>
-            <attack/>
-            <evidence>b_id=48288</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48289</param>
-            <attack/>
-            <evidence>b_id=48289</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48290</param>
-            <attack/>
-            <evidence>b_id=48290</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48292</param>
-            <attack/>
-            <evidence>b_id=48292</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48293</param>
-            <attack/>
-            <evidence>b_id=48293</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48294</param>
-            <attack/>
-            <evidence>b_id=48294</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48295</param>
-            <attack/>
-            <evidence>b_id=48295</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48296</param>
-            <attack/>
-            <evidence>b_id=48296</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48298</param>
-            <attack/>
-            <evidence>b_id=48298</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48297</param>
-            <attack/>
-            <evidence>b_id=48297</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48299</param>
-            <attack/>
-            <evidence>b_id=48299</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48300</param>
-            <attack/>
-            <evidence>b_id=48300</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48301</param>
-            <attack/>
-            <evidence>b_id=48301</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48302</param>
-            <attack/>
-            <evidence>b_id=48302</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48303</param>
-            <attack/>
-            <evidence>b_id=48303</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48304</param>
-            <attack/>
-            <evidence>b_id=48304</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48305</param>
-            <attack/>
-            <evidence>b_id=48305</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48306</param>
-            <attack/>
-            <evidence>b_id=48306</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48307</param>
-            <attack/>
-            <evidence>b_id=48307</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48308</param>
-            <attack/>
-            <evidence>b_id=48308</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48309</param>
-            <attack/>
-            <evidence>b_id=48309</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48310</param>
-            <attack/>
-            <evidence>b_id=48310</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48311</param>
-            <attack/>
-            <evidence>b_id=48311</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48312</param>
-            <attack/>
-            <evidence>b_id=48312</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48313</param>
-            <attack/>
-            <evidence>b_id=48313</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48314</param>
-            <attack/>
-            <evidence>b_id=48314</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48315</param>
-            <attack/>
-            <evidence>b_id=48315</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48317</param>
-            <attack/>
-            <evidence>b_id=48317</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48316</param>
-            <attack/>
-            <evidence>b_id=48316</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48318</param>
-            <attack/>
-            <evidence>b_id=48318</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48319</param>
-            <attack/>
-            <evidence>b_id=48319</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48320</param>
-            <attack/>
-            <evidence>b_id=48320</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48321</param>
-            <attack/>
-            <evidence>b_id=48321</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48322</param>
-            <attack/>
-            <evidence>b_id=48322</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48323</param>
-            <attack/>
-            <evidence>b_id=48323</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48324</param>
-            <attack/>
-            <evidence>b_id=48324</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48325</param>
-            <attack/>
-            <evidence>b_id=48325</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48327</param>
-            <attack/>
-            <evidence>b_id=48327</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>10010</pluginid>
-            <alert>Cookie set without HttpOnly flag</alert>
-            <riskcode>1</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>Low (Medium)</riskdesc>
-            <desc>A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>b_id=48328</param>
-            <attack/>
-            <evidence>b_id=48328</evidence>
-            <otherinfo/>
-            <solution>Ensure that the HttpOnly flag is set for all cookies.
-            </solution>
-            <reference>www.owasp.org/index.php/HttpOnly
-            </reference>
-            <wascid>13</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>40018</pluginid>
-            <alert>Injection SQL</alert>
-            <riskcode>3</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>High (Medium)</riskdesc>
-            <desc>Une injection SQL peut être possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/basket.jsp</uri>
-            <param>productid</param>
-            <attack>5-2</attack>
-            <otherinfo>Les résultats de la page originale ont été reproduits avec succès en utilisant l'expression [5-2] comme valeur du paramètre
-                La valeur du paramètre NOT  en cours de modification est extraite de la sortie HTML à fin de comparaison</otherinfo>
-            <solution>Ne faites pas confiance aux entrées du côté client, même si des mécanismes de validation sont en place côté client.
-                En général, contrôlez du côté serveur le type de chaque donnée.
-                Si l'application utilise JDBC, utilisez les PreparedStatement ou CallableStatement, avec les paramètres passés par '?'
-                Si l'application utilise ASP, utilisez les Objects de Commande ADO avec un typage fort et des requêtes paramétrées.
-                Si l'utilisation de Procédure Stockées est possible, utilisez-les.
-                Ne concaténez *pas* les chaînes de caractères dans les requêtes des procédures stockées, ou utilisez les fonctions 'exec', 'exec immediate' ou d'autre fonctions équivalentes!
-                Ne créez pas des requêtes SQL dynamiques par simples concaténation de chaînes de caractères.
-                Échappez toutes les données reçues du client.
-                Appliquez une 'liste blanche' des caractères autorisés, ou une 'liste noir' des caractères interdits dans les entrées de l'utilisateur.
-                Appliquez le principe de moindre privilège en utilisant les privilèges utilisateur minimaux sur la base de donnée.
-                En particulier, évitez l'utilisation des utilisateurs 'sa' ou 'db-owner'. Ceci n'évite pas les injections SQL, mais minimise leur impact.
-                Accordez les plus faibles droits d'accès aux bases de données nécessaires à l'application.
-            </solution>
-            <otherinfo>Les résultats de la page originale ont été reproduits avec succès en utilisant l'expression [5-2] comme valeur du paramètre
-                La valeur du paramètre NOT  en cours de modification est extraite de la sortie HTML à fin de comparaison
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/Top_10_2010-A1
-                https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet
-            </reference>
-            <cweid>89</cweid>
-            <wascid>19</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>40018</pluginid>
-            <alert>Injection SQL</alert>
-            <riskcode>3</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>High (Medium)</riskdesc>
-            <desc>Une injection SQL peut être possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/advanced.jsp</uri>
-            <param>q</param>
-            <attack>%</attack>
-            <otherinfo>Les résultats de la page ont été manipulés avec succès en utilisant les conditions booléennes [%] et [XYZABCDEFGHIJ]
-                La valeur du paramètre en cours de modification NOT  est extraite de la sortie HTML à fin de comparaison
-                La donnée a été retournée pour le paramètre d'origine.
-                La vulnérabilité a été détectée en manipulant le paramètre, ce qui a restreint avec succès les données initialement retournées,</otherinfo>
-            <solution>Ne faites pas confiance aux entrées du côté client, même si des mécanismes de validation sont en place côté client.
-                En général, contrôlez du côté serveur le type de chaque donnée.
-                Si l'application utilise JDBC, utilisez les PreparedStatement ou CallableStatement, avec les paramètres passés par '?'
-                Si l'application utilise ASP, utilisez les Objects de Commande ADO avec un typage fort et des requêtes paramétrées.
-                Si l'utilisation de Procédure Stockées est possible, utilisez-les.
-                Ne concaténez *pas* les chaînes de caractères dans les requêtes des procédures stockées, ou utilisez les fonctions 'exec', 'exec immediate' ou d'autre fonctions équivalentes!
-                Ne créez pas des requêtes SQL dynamiques par simples concaténation de chaînes de caractères.
-                Échappez toutes les données reçues du client.
-                Appliquez une 'liste blanche' des caractères autorisés, ou une 'liste noir' des caractères interdits dans les entrées de l'utilisateur.
-                Appliquez le principe de moindre privilège en utilisant les privilèges utilisateur minimaux sur la base de donnée.
-                En particulier, évitez l'utilisation des utilisateurs 'sa' ou 'db-owner'. Ceci n'évite pas les injections SQL, mais minimise leur impact.
-                Accordez les plus faibles droits d'accès aux bases de données nécessaires à l'application.
-            </solution>
-            <otherinfo>Les résultats de la page ont été manipulés avec succès en utilisant les conditions booléennes [%] et [XYZABCDEFGHIJ]
-                La valeur du paramètre en cours de modification NOT  est extraite de la sortie HTML à fin de comparaison
-                La donnée a été retournée pour le paramètre d'origine.
-                La vulnérabilité a été détectée en manipulant le paramètre, ce qui a restreint avec succès les données initialement retournées,
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/Top_10_2010-A1
-                https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet
-            </reference>
-            <cweid>89</cweid>
-            <wascid>19</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>40018</pluginid>
-            <alert>Injection SQL</alert>
-            <riskcode>3</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>High (Medium)</riskdesc>
-            <desc>Une injection SQL peut être possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/advanced.jsp</uri>
-            <param>q</param>
-            <attack>%</attack>
-            <otherinfo>Les résultats de la page ont été manipulés avec succès en utilisant les conditions booléennes [%] et [XYZABCDEFGHIJ]
-                La valeur du paramètre en cours de modification  est extraite de la sortie HTML à fin de comparaison
-                La donnée a été retournée pour le paramètre d'origine.
-                La vulnérabilité a été détectée en manipulant le paramètre, ce qui a restreint avec succès les données initialement retournées,</otherinfo>
-            <solution>Ne faites pas confiance aux entrées du côté client, même si des mécanismes de validation sont en place côté client.
-                En général, contrôlez du côté serveur le type de chaque donnée.
-                Si l'application utilise JDBC, utilisez les PreparedStatement ou CallableStatement, avec les paramètres passés par '?'
-                Si l'application utilise ASP, utilisez les Objects de Commande ADO avec un typage fort et des requêtes paramétrées.
-                Si l'utilisation de Procédure Stockées est possible, utilisez-les.
-                Ne concaténez *pas* les chaînes de caractères dans les requêtes des procédures stockées, ou utilisez les fonctions 'exec', 'exec immediate' ou d'autre fonctions équivalentes!
-                Ne créez pas des requêtes SQL dynamiques par simples concaténation de chaînes de caractères.
-                Échappez toutes les données reçues du client.
-                Appliquez une 'liste blanche' des caractères autorisés, ou une 'liste noir' des caractères interdits dans les entrées de l'utilisateur.
-                Appliquez le principe de moindre privilège en utilisant les privilèges utilisateur minimaux sur la base de donnée.
-                En particulier, évitez l'utilisation des utilisateurs 'sa' ou 'db-owner'. Ceci n'évite pas les injections SQL, mais minimise leur impact.
-                Accordez les plus faibles droits d'accès aux bases de données nécessaires à l'application.
-            </solution>
-            <otherinfo>Les résultats de la page ont été manipulés avec succès en utilisant les conditions booléennes [%] et [XYZABCDEFGHIJ]
-                La valeur du paramètre en cours de modification  est extraite de la sortie HTML à fin de comparaison
-                La donnée a été retournée pour le paramètre d'origine.
-                La vulnérabilité a été détectée en manipulant le paramètre, ce qui a restreint avec succès les données initialement retournées,
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/Top_10_2010-A1
-                https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet
-            </reference>
-            <cweid>89</cweid>
-            <wascid>19</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>40018</pluginid>
-            <alert>Injection SQL</alert>
-            <riskcode>3</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>High (Medium)</riskdesc>
-            <desc>Une injection SQL peut être possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/login.jsp</uri>
-            <param>password</param>
-            <attack>ZAP' OR '1'='1</attack>
-            <otherinfo>Les résultats de la page ont été manipulés avec succès en utilisant les conditions booléennes [ZAP' AND '1'='1] et [ZAP' OR '1'='1]
-                La valeur du paramètre en cours de modification NOT  est extraite de la sortie HTML à fin de comparaison
-                Les données n'ont PAS été retournées pour le paramètre d'origine.
-                La vulnérabilité a été détectée en manipulant le paramètre pour récupérer avec succès plus de données qu'initialement retournées,</otherinfo>
-            <solution>Ne faites pas confiance aux entrées du côté client, même si des mécanismes de validation sont en place côté client.
-                En général, contrôlez du côté serveur le type de chaque donnée.
-                Si l'application utilise JDBC, utilisez les PreparedStatement ou CallableStatement, avec les paramètres passés par '?'
-                Si l'application utilise ASP, utilisez les Objects de Commande ADO avec un typage fort et des requêtes paramétrées.
-                Si l'utilisation de Procédure Stockées est possible, utilisez-les.
-                Ne concaténez *pas* les chaînes de caractères dans les requêtes des procédures stockées, ou utilisez les fonctions 'exec', 'exec immediate' ou d'autre fonctions équivalentes!
-                Ne créez pas des requêtes SQL dynamiques par simples concaténation de chaînes de caractères.
-                Échappez toutes les données reçues du client.
-                Appliquez une 'liste blanche' des caractères autorisés, ou une 'liste noir' des caractères interdits dans les entrées de l'utilisateur.
-                Appliquez le principe de moindre privilège en utilisant les privilèges utilisateur minimaux sur la base de donnée.
-                En particulier, évitez l'utilisation des utilisateurs 'sa' ou 'db-owner'. Ceci n'évite pas les injections SQL, mais minimise leur impact.
-                Accordez les plus faibles droits d'accès aux bases de données nécessaires à l'application.
-            </solution>
-            <otherinfo>Les résultats de la page ont été manipulés avec succès en utilisant les conditions booléennes [ZAP' AND '1'='1] et [ZAP' OR '1'='1]
-                La valeur du paramètre en cours de modification NOT  est extraite de la sortie HTML à fin de comparaison
-                Les données n'ont PAS été retournées pour le paramètre d'origine.
-                La vulnérabilité a été détectée en manipulant le paramètre pour récupérer avec succès plus de données qu'initialement retournées,
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/Top_10_2010-A1
-                https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet
-            </reference>
-            <cweid>89</cweid>
-            <wascid>19</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>40018</pluginid>
-            <alert>Injection SQL</alert>
-            <riskcode>3</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>High (Medium)</riskdesc>
-            <desc>Une injection SQL peut être possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/login.jsp</uri>
-            <param>password</param>
-            <attack>ZAP' OR '1'='1</attack>
-            <otherinfo>Les résultats de la page ont été manipulés avec succès en utilisant les conditions booléennes [ZAP' AND '1'='1] et [ZAP' OR '1'='1]
-                La valeur du paramètre en cours de modification  est extraite de la sortie HTML à fin de comparaison
-                Les données n'ont PAS été retournées pour le paramètre d'origine.
-                La vulnérabilité a été détectée en manipulant le paramètre pour récupérer avec succès plus de données qu'initialement retournées,</otherinfo>
-            <solution>Ne faites pas confiance aux entrées du côté client, même si des mécanismes de validation sont en place côté client.
-                En général, contrôlez du côté serveur le type de chaque donnée.
-                Si l'application utilise JDBC, utilisez les PreparedStatement ou CallableStatement, avec les paramètres passés par '?'
-                Si l'application utilise ASP, utilisez les Objects de Commande ADO avec un typage fort et des requêtes paramétrées.
-                Si l'utilisation de Procédure Stockées est possible, utilisez-les.
-                Ne concaténez *pas* les chaînes de caractères dans les requêtes des procédures stockées, ou utilisez les fonctions 'exec', 'exec immediate' ou d'autre fonctions équivalentes!
-                Ne créez pas des requêtes SQL dynamiques par simples concaténation de chaînes de caractères.
-                Échappez toutes les données reçues du client.
-                Appliquez une 'liste blanche' des caractères autorisés, ou une 'liste noir' des caractères interdits dans les entrées de l'utilisateur.
-                Appliquez le principe de moindre privilège en utilisant les privilèges utilisateur minimaux sur la base de donnée.
-                En particulier, évitez l'utilisation des utilisateurs 'sa' ou 'db-owner'. Ceci n'évite pas les injections SQL, mais minimise leur impact.
-                Accordez les plus faibles droits d'accès aux bases de données nécessaires à l'application.
-            </solution>
-            <otherinfo>Les résultats de la page ont été manipulés avec succès en utilisant les conditions booléennes [ZAP' AND '1'='1] et [ZAP' OR '1'='1]
-                La valeur du paramètre en cours de modification  est extraite de la sortie HTML à fin de comparaison
-                Les données n'ont PAS été retournées pour le paramètre d'origine.
-                La vulnérabilité a été détectée en manipulant le paramètre pour récupérer avec succès plus de données qu'initialement retournées,
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/Top_10_2010-A1
-                https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet
-            </reference>
-            <cweid>89</cweid>
-            <wascid>19</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>40018</pluginid>
-            <alert>Injection SQL</alert>
-            <riskcode>3</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>High (Medium)</riskdesc>
-            <desc>Une injection SQL peut être possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/register.jsp</uri>
-            <param>username</param>
-            <attack>ZAP%</attack>
-            <otherinfo>Les résultats de la page ont été manipulés avec succès en utilisant les conditions booléennes [ZAP%] et [ZAPXYZABCDEFGHIJ]
-                La valeur du paramètre en cours de modification NOT  est extraite de la sortie HTML à fin de comparaison
-                La donnée a été retournée pour le paramètre d'origine.
-                La vulnérabilité a été détectée en manipulant le paramètre, ce qui a restreint avec succès les données initialement retournées,</otherinfo>
-            <solution>Ne faites pas confiance aux entrées du côté client, même si des mécanismes de validation sont en place côté client.
-                En général, contrôlez du côté serveur le type de chaque donnée.
-                Si l'application utilise JDBC, utilisez les PreparedStatement ou CallableStatement, avec les paramètres passés par '?'
-                Si l'application utilise ASP, utilisez les Objects de Commande ADO avec un typage fort et des requêtes paramétrées.
-                Si l'utilisation de Procédure Stockées est possible, utilisez-les.
-                Ne concaténez *pas* les chaînes de caractères dans les requêtes des procédures stockées, ou utilisez les fonctions 'exec', 'exec immediate' ou d'autre fonctions équivalentes!
-                Ne créez pas des requêtes SQL dynamiques par simples concaténation de chaînes de caractères.
-                Échappez toutes les données reçues du client.
-                Appliquez une 'liste blanche' des caractères autorisés, ou une 'liste noir' des caractères interdits dans les entrées de l'utilisateur.
-                Appliquez le principe de moindre privilège en utilisant les privilèges utilisateur minimaux sur la base de donnée.
-                En particulier, évitez l'utilisation des utilisateurs 'sa' ou 'db-owner'. Ceci n'évite pas les injections SQL, mais minimise leur impact.
-                Accordez les plus faibles droits d'accès aux bases de données nécessaires à l'application.
-            </solution>
-            <otherinfo>Les résultats de la page ont été manipulés avec succès en utilisant les conditions booléennes [ZAP%] et [ZAPXYZABCDEFGHIJ]
-                La valeur du paramètre en cours de modification NOT  est extraite de la sortie HTML à fin de comparaison
-                La donnée a été retournée pour le paramètre d'origine.
-                La vulnérabilité a été détectée en manipulant le paramètre, ce qui a restreint avec succès les données initialement retournées,
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/Top_10_2010-A1
-                https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet
-            </reference>
-            <cweid>89</cweid>
-            <wascid>19</wascid>
-        </alertitem>
-        <alertitem>
-            <pluginid>40018</pluginid>
-            <alert>Injection SQL</alert>
-            <riskcode>3</riskcode>
-            <confidence>2</confidence>
-            <riskdesc>High (Medium)</riskdesc>
-            <desc>Une injection SQL peut être possible.
-            </desc>
-            <uri>http://localhost:8180/bodgeit/register.jsp</uri>
-            <param>username</param>
-            <attack>ZAP%</attack>
-            <otherinfo>Les résultats de la page ont été manipulés avec succès en utilisant les conditions booléennes [ZAP%] et [ZAPXYZABCDEFGHIJ]
-                La valeur du paramètre en cours de modification  est extraite de la sortie HTML à fin de comparaison
-                La donnée a été retournée pour le paramètre d'origine.
-                La vulnérabilité a été détectée en manipulant le paramètre, ce qui a restreint avec succès les données initialement retournées,</otherinfo>
-            <solution>Ne faites pas confiance aux entrées du côté client, même si des mécanismes de validation sont en place côté client.
-                En général, contrôlez du côté serveur le type de chaque donnée.
-                Si l'application utilise JDBC, utilisez les PreparedStatement ou CallableStatement, avec les paramètres passés par '?'
-                Si l'application utilise ASP, utilisez les Objects de Commande ADO avec un typage fort et des requêtes paramétrées.
-                Si l'utilisation de Procédure Stockées est possible, utilisez-les.
-                Ne concaténez *pas* les chaînes de caractères dans les requêtes des procédures stockées, ou utilisez les fonctions 'exec', 'exec immediate' ou d'autre fonctions équivalentes!
-                Ne créez pas des requêtes SQL dynamiques par simples concaténation de chaînes de caractères.
-                Échappez toutes les données reçues du client.
-                Appliquez une 'liste blanche' des caractères autorisés, ou une 'liste noir' des caractères interdits dans les entrées de l'utilisateur.
-                Appliquez le principe de moindre privilège en utilisant les privilèges utilisateur minimaux sur la base de donnée.
-                En particulier, évitez l'utilisation des utilisateurs 'sa' ou 'db-owner'. Ceci n'évite pas les injections SQL, mais minimise leur impact.
-                Accordez les plus faibles droits d'accès aux bases de données nécessaires à l'application.
-            </solution>
-            <otherinfo>Les résultats de la page ont été manipulés avec succès en utilisant les conditions booléennes [ZAP%] et [ZAPXYZABCDEFGHIJ]
-                La valeur du paramètre en cours de modification  est extraite de la sortie HTML à fin de comparaison
-                La donnée a été retournée pour le paramètre d'origine.
-                La vulnérabilité a été détectée en manipulant le paramètre, ce qui a restreint avec succès les données initialement retournées,
-            </otherinfo>
-            <reference>https://www.owasp.org/index.php/Top_10_2010-A1
-                https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet
-            </reference>
-            <cweid>89</cweid>
-            <wascid>19</wascid>
-        </alertitem>
-    </alerts></site></OWASPZAPReport>
+    </alerts></site><site name="https://example3.org" host="example3.org" port="443" ssl="true"><alerts><alertitem>
+    <pluginid>90011</pluginid>
+    <alert>Charset Mismatch </alert>
+    <name>Charset Mismatch </name>
+    <riskcode>0</riskcode>
+    <confidence>1</confidence>
+    <riskdesc>Informational (Low)</riskdesc>
+    <desc>&lt;p&gt;This check identifies responses where the HTTP Content-Type header declares a charset different from the charset defined by the body of the HTML or XML. When there&apos;s a charset mismatch between the HTTP header and content body Web browsers can be forced into an undesirable content-sniffing mode to determine the content&apos;s correct character set.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;An attacker could manipulate content on the page to be interpreted in an encoding of their choice. For example, if an attacker can control content at the beginning of the page, they could inject script using UTF-7 encoded text and manipulate some browsers into interpreting that text.&lt;/p&gt;</desc>
+    <instances>
+        <instance>
+            <uri>https://example3.org</uri>
+            <method>GET</method>
+        </instance>
+    </instances>
+    <count>1</count>
+    <solution>&lt;p&gt;Force UTF-8 for all text content in both the HTTP header and meta tags in HTML or encoding declarations in XML.&lt;/p&gt;</solution>
+    <otherinfo>&lt;p&gt;There was a charset mismatch between the HTTP Header and the XML encoding declaration: [utf-8] and [null] do not match.&lt;/p&gt;</otherinfo>
+    <reference>&lt;p&gt;http://code.google.com/p/browsersec/wiki/Part2#Character_set_handling_and_detection&lt;/p&gt;</reference>
+    <cweid>16</cweid>
+    <wascid>15</wascid>
+    <sourceid>3</sourceid>
+</alertitem>
+    <alertitem>
+        <pluginid>10015</pluginid>
+        <alert>Incomplete or No Cache-control and Pragma HTTP Header Set</alert>
+        <name>Incomplete or No Cache-control and Pragma HTTP Header Set</name>
+        <riskcode>1</riskcode>
+        <confidence>2</confidence>
+        <riskdesc>Low (Medium)</riskdesc>
+        <desc>&lt;p&gt;The cache-control and pragma HTTP header have not been set properly or are missing allowing the browser and proxies to cache content.&lt;/p&gt;</desc>
+        <instances>
+            <instance>
+                <uri>https://example3.org</uri>
+                <method>GET</method>
+                <param>Cache-Control</param>
+                <evidence>public, max-age=90</evidence>
+            </instance>
+        </instances>
+        <count>1</count>
+        <solution>&lt;p&gt;Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate; and that the pragma HTTP header is set with no-cache.&lt;/p&gt;</solution>
+        <reference>&lt;p&gt;https://example2.org</reference>
+        <cweid>525</cweid>
+        <wascid>13</wascid>
+        <sourceid>3</sourceid>
+    </alertitem>
+</alerts></site><site name="https://example4.org" host="example4.org" port="443" ssl="true"><alerts><alertitem>
+    <pluginid>10021</pluginid>
+    <alert>X-Content-Type-Options Header Missing</alert>
+    <name>X-Content-Type-Options Header Missing</name>
+    <riskcode>1</riskcode>
+    <confidence>2</confidence>
+    <riskdesc>Low (Medium)</riskdesc>
+    <desc>&lt;p&gt;The Anti-MIME-Sniffing header X-Content-Type-Options was not set to &apos;nosniff&apos;. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.&lt;/p&gt;</desc>
+    <instances>
+        <instance>
+            <uri>https://example4.org</uri>
+            <method>GET</method>
+            <param>X-Content-Type-Options</param>
+        </instance>
+        <instance>
+            <uri>https://example4.org</uri>
+            <method>GET</method>
+            <param>X-Content-Type-Options</param>
+        </instance>
+    </instances>
+    <count>2</count>
+    <solution>&lt;p&gt;Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to &apos;nosniff&apos; for all web pages.&lt;/p&gt;&lt;p&gt;If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.&lt;/p&gt;</solution>
+    <otherinfo>&lt;p&gt;This issue still applies to error type pages (401, 403, 500, etc) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.&lt;/p&gt;&lt;p&gt;At &quot;High&quot; threshold this scanner will not alert on client or server error responses.&lt;/p&gt;</otherinfo>
+    <reference>&lt;p&gt;http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx&lt;/p&gt;&lt;p&gt;https://example2.org</reference>
+    <cweid>16</cweid>
+    <wascid>15</wascid>
+    <sourceid>3</sourceid>
+</alertitem>
+</alerts></site><site name="https://example5.org" host="example5.org" port="443" ssl="true"><alerts><alertitem>
+    <pluginid>10021</pluginid>
+    <alert>X-Content-Type-Options Header Missing</alert>
+    <name>X-Content-Type-Options Header Missing</name>
+    <riskcode>1</riskcode>
+    <confidence>2</confidence>
+    <riskdesc>Low (Medium)</riskdesc>
+    <desc>&lt;p&gt;The Anti-MIME-Sniffing header X-Content-Type-Options was not set to &apos;nosniff&apos;. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.&lt;/p&gt;</desc>
+    <instances>
+        <instance>
+            <uri>https://example5.org</uri>
+            <method>POST</method>
+            <param>X-Content-Type-Options</param>
+        </instance>
+    </instances>
+    <count>1</count>
+    <solution>&lt;p&gt;Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to &apos;nosniff&apos; for all web pages.&lt;/p&gt;&lt;p&gt;If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.&lt;/p&gt;</solution>
+    <otherinfo>&lt;p&gt;This issue still applies to error type pages (401, 403, 500, etc) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.&lt;/p&gt;&lt;p&gt;At &quot;High&quot; threshold this scanner will not alert on client or server error responses.&lt;/p&gt;</otherinfo>
+    <reference>&lt;p&gt;http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx&lt;/p&gt;&lt;p&gt;https://example2.org</reference>
+    <cweid>16</cweid>
+    <wascid>15</wascid>
+    <sourceid>3</sourceid>
+</alertitem>
+</alerts></site><site name="https://example6.org" host="example6.org" port="443" ssl="true"><alerts><alertitem>
+    <pluginid>10021</pluginid>
+    <alert>X-Content-Type-Options Header Missing</alert>
+    <name>X-Content-Type-Options Header Missing</name>
+    <riskcode>1</riskcode>
+    <confidence>2</confidence>
+    <riskdesc>Low (Medium)</riskdesc>
+    <desc>&lt;p&gt;The Anti-MIME-Sniffing header X-Content-Type-Options was not set to &apos;nosniff&apos;. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.&lt;/p&gt;</desc>
+    <instances>
+        <instance>
+            <uri>https://example6.org</uri>
+            <method>GET</method>
+            <param>X-Content-Type-Options</param>
+        </instance>
+    </instances>
+    <count>1</count>
+    <solution>&lt;p&gt;Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to &apos;nosniff&apos; for all web pages.&lt;/p&gt;&lt;p&gt;If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.&lt;/p&gt;</solution>
+    <otherinfo>&lt;p&gt;This issue still applies to error type pages (401, 403, 500, etc) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.&lt;/p&gt;&lt;p&gt;At &quot;High&quot; threshold this scanner will not alert on client or server error responses.&lt;/p&gt;</otherinfo>
+    <reference>&lt;p&gt;http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx&lt;/p&gt;&lt;p&gt;https://example2.org</reference>
+    <cweid>16</cweid>
+    <wascid>15</wascid>
+    <sourceid>3</sourceid>
+</alertitem>
+    <alertitem>
+        <pluginid>10015</pluginid>
+        <alert>Incomplete or No Cache-control and Pragma HTTP Header Set</alert>
+        <name>Incomplete or No Cache-control and Pragma HTTP Header Set</name>
+        <riskcode>1</riskcode>
+        <confidence>2</confidence>
+        <riskdesc>Low (Medium)</riskdesc>
+        <desc>&lt;p&gt;The cache-control and pragma HTTP header have not been set properly or are missing allowing the browser and proxies to cache content.&lt;/p&gt;</desc>
+        <instances>
+            <instance>
+                <uri>https://example6.org</uri>
+                <method>GET</method>
+                <param>Cache-Control</param>
+                <evidence>public, max-age=30672000</evidence>
+            </instance>
+        </instances>
+        <count>1</count>
+        <solution>&lt;p&gt;Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate; and that the pragma HTTP header is set with no-cache.&lt;/p&gt;</solution>
+        <reference>&lt;p&gt;https://example2.org</reference>
+        <cweid>525</cweid>
+        <wascid>13</wascid>
+        <sourceid>3</sourceid>
+    </alertitem>
+    <alertitem>
+        <pluginid>10025</pluginid>
+        <alert>Information Disclosure - Sensitive Information in HTTP Referrer Header</alert>
+        <name>Information Disclosure - Sensitive Information in HTTP Referrer Header</name>
+        <riskcode>0</riskcode>
+        <confidence>2</confidence>
+        <riskdesc>Informational (Medium)</riskdesc>
+        <desc>&lt;p&gt;The HTTP header may have leaked a potentially sensitive parameter to another domain. This can violate PCI and most organizational compliance policies. You can configure the list of strings for this check to add or remove values specific to your environment.&lt;/p&gt;</desc>
+        <instances>
+            <instance>
+                <uri>https://example6.org</uri>
+                <method>GET</method>
+                <evidence>user</evidence>
+            </instance>
+        </instances>
+        <count>1</count>
+        <solution>&lt;p&gt;Do not pass sensitive information in URIs.&lt;/p&gt;</solution>
+        <otherinfo>&lt;p&gt;The URL in the HTTP referrer header field appears to contain sensitive information.&lt;/p&gt;</otherinfo>
+        <reference>&lt;p&gt;&lt;/p&gt;</reference>
+        <cweid>200</cweid>
+        <wascid>13</wascid>
+        <sourceid>3</sourceid>
+    </alertitem>
+</alerts></site><site name="http://testsite" host="testsite" port="80" ssl="false"><alerts><alertitem>
+    <pluginid>10016</pluginid>
+    <alert>Web Browser XSS Protection Not Enabled</alert>
+    <name>Web Browser XSS Protection Not Enabled</name>
+    <riskcode>1</riskcode>
+    <confidence>2</confidence>
+    <riskdesc>Low (Medium)</riskdesc>
+    <desc>&lt;p&gt;Web Browser XSS Protection is not enabled, or is disabled by the configuration of the &apos;X-XSS-Protection&apos; HTTP response header on the web server&lt;/p&gt;</desc>
+    <instances>
+        <instance>
+            <uri>http://testsite/users/drupal-dast-cdn/assets/drupal-dast-cdn/assets/favicon/favicon-32x32.png</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/users/drupal-dast-cdn/assets/svg/drupal-dast-cdn/assets/favicon/apple-icon-152x152.png</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/users/drupal-dast-cdn/assets/svg/logo/drupal-dast-cdn/assets/favicon/apple-icon-76x76.png</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/sites/all/modules/contrib/jquery_update/replace/jquery.form/</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/user/drupal-dast-cdn/drupal-dast-cdn/assets/favicon/apple-icon-57x57.png</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/misc/drupal-dast-cdn/assets/favicon/drupal-dast-cdn/assets/svg/logo/logo.svg</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/xmlrpc.php</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/user/drupal-dast-cdn/drupal-dast-cdn/assets/favicon/manifest.json</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/profiles/drupal-dast-cdn/assets/favicon/apple-icon-76x76.png</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/user/register/drupal-dast-cdn/assets/favicon/apple-icon-144x144.png</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/drupal-dast-cdn/assets/svg/logo/drupal-dast-cdn/assets/svg/logo/logo-footer.svg</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/sites/default/files/drupal-dast-cdn/assets/favicon/drupal-dast-cdn/assets/favicon/manifest.json</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/user/login/drupal-dast-cdn/assets/favicon/apple-icon-76x76.png</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/drupal-dast-cdn/assets/favicon/apple-icon.png</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/themes/drupal-dast-cdn/assets/favicon/apple-icon-72x72.png</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/user/drupal-dast-cdn/assets/svg/drupal-dast-cdn/assets/favicon/drupal-dast-cdn/assets/favicon/apple-icon-180x180.png</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/user/drupal-dast-cdn/assets/svg/drupal-dast-cdn/assets/svg/logo/logo.svg</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/users/admin</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/user/drupal-dast-cdn/drupal-dast-cdn/assets/favicon/drupal-dast-cdn/assets/favicon/apple-icon-72x72.png</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+        <instance>
+            <uri>http://testsite/modules/field/</uri>
+            <method>GET</method>
+            <param>X-XSS-Protection</param>
+        </instance>
+    </instances>
+    <count>840</count>
+    <solution>&lt;p&gt;Ensure that the web browser&apos;s XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to &apos;1&apos;.&lt;/p&gt;</solution>
+    <otherinfo>&lt;p&gt;The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser&apos;s XSS protection mechanism. The following values would attempt to enable it: &lt;/p&gt;&lt;p&gt;X-XSS-Protection: 1; mode=block&lt;/p&gt;&lt;p&gt;X-XSS-Protection: 1; report=http://www.example.com/xss&lt;/p&gt;&lt;p&gt;The following values would disable it:&lt;/p&gt;&lt;p&gt;X-XSS-Protection: 0&lt;/p&gt;&lt;p&gt;The X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).&lt;/p&gt;&lt;p&gt;Note that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).&lt;/p&gt;</otherinfo>
+    <reference>&lt;p&gt;https://example2.org</reference>
+    <cweid>933</cweid>
+    <wascid>14</wascid>
+    <sourceid>3</sourceid>
+</alertitem>
+    <alertitem>
+        <pluginid>10027</pluginid>
+        <alert>Information Disclosure - Suspicious Comments</alert>
+        <name>Information Disclosure - Suspicious Comments</name>
+        <riskcode>0</riskcode>
+        <confidence>2</confidence>
+        <riskdesc>Informational (Medium)</riskdesc>
+        <desc>&lt;p&gt;The response appears to contain suspicious comments which may help an attacker.&lt;/p&gt;</desc>
+        <instances>
+            <instance>
+                <uri>http://testsite/sites/default/files/drupal-dast-cdn/assets/favicon/drupal-dast-cdn/assets/svg/logo/logo-footer.svg</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/sites/default/files/styles/themecard/public/drupal-dast-cdn/assets/favicon/favicon.ico</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/login/drupal-dast-cdn/assets/favicon/favicon.ico</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/drupal-dast-cdn/assets/svg/logo/logo.svg</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/sites/all/modules/contrib/views/js/base.js?p5a3zr</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/login/drupal-dast-cdn/assets/favicon/apple-icon-72x72.png</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/misc/jquery.js?v=1.4.4</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/sites/default/files/styles/themecard/public/drupal-dast-cdn/assets/favicon/favicon-96x96.png</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/themes/drupal-dast-cdn/assets/favicon/manifest.json</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/password/drupal-dast-cdn/assets/favicon/favicon-32x32.png</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/password/drupal-dast-cdn/assets/favicon/favicon.ico</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/password/drupal-dast-cdn/assets/favicon/apple-icon-76x76.png</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/users/drupal-dast-cdn</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/admin/drupal-dast-cdn/assets/favicon/apple-icon-120x120.png</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/login/drupal-dast-cdn/assets/favicon/apple-icon-76x76.png</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/inloggen</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/password/drupal-dast-cdn/assets/favicon/manifest.json</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/comment/reply/</uri>
+                <method>GET</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/login/</uri>
+                <method>POST</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/404-pagina-niet-gevonden</uri>
+                <method>GET</method>
+            </instance>
+        </instances>
+        <count>306</count>
+        <solution>&lt;p&gt;Remove all comments that return information that may help an attacker and fix any underlying problems they refer to.&lt;/p&gt;</solution>
+        <otherinfo>&lt;p&gt;&lt;!-- TODO: Add ARIA roles - see example in header.tpl.php --&gt;&lt;/p&gt;&lt;p&gt;&lt;script type=&quot;text/javascript&quot;&gt;&lt;/p&gt;&lt;p&gt;&lt;!--//--&gt;&lt;![CDATA[//&gt;&lt;!--&lt;/p&gt;&lt;p&gt;jQuery.extend(Drupal.settings, {&quot;basePath&quot;:&quot;\/&quot;,&quot;pathPrefix&quot;:&quot;&quot;,&quot;ajaxPageState&quot;:{&quot;theme&quot;:&quot;whitelabel&quot;,&quot;theme_token&quot;:&quot;vW3qeURAE3ivzne7RDhmCB-MX1Slgfvdv4G4DvfMyTM&quot;,&quot;jquery_version&quot;:&quot;2.2&quot;,&quot;js&quot;:{&quot;sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/2.2\/jquery.min.js&quot;:1,&quot;misc\/jquery.once.js&quot;:1,&quot;misc\/drupal.js&quot;:1,&quot;sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/external\/jquery.cookie.js&quot;:1,&quot;sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery.form\/4\/jquery.form.min.js&quot;:1,&quot;misc\/ajax.js&quot;:1,&quot;sites\/all\/modules\/contrib\/jquery_update\/js\/jquery_update.js&quot;:1,&quot;sites\/all\/modules\/contrib\/ctools\/js\/auto-submit.js&quot;:1,&quot;sites\/all\/modules\/contrib\/views\/js\/base.js&quot;:1,&quot;misc\/progress.js&quot;:1,&quot;sites\/all\/modules\/contrib\/views\/js\/ajax_view.js&quot;:1,&quot;sites\/all\/themes\/whitelabel\/js\/components.js&quot;:1},&quot;css&quot;:{&quot;modules\/system\/system.messages.css&quot;:1,&quot;sites\/all\/modules\/tkp_legacy\/demo_login\/style\/demo_login.css&quot;:1,&quot;modules\/field\/theme\/field.css&quot;:1,&quot;modules\/node\/node.css&quot;:1,&quot;modules\/user\/user.css&quot;:1,&quot;sites\/all\/modules\/contrib\/views\/css\/views.css&quot;:1,&quot;sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css&quot;:1,&quot;sites\/all\/modules\/contrib\/media\/modules\/media_wysiwyg\/css\/media_wysiwyg.base.css&quot;:1,&quot;sites\/all\/modules\/contrib\/ctools\/css\/ctools.css&quot;:1}},&quot;urlIsAjaxTrusted&quot;:{&quot;\/&quot;:true,&quot;\/views\/ajax&quot;:true},&quot;views&quot;:{&quot;ajax_path&quot;:&quot;\/views\/ajax&quot;,&quot;ajaxViews&quot;:{&quot;views_dom_id:f2bb4d79020da034afcf982945205b53&quot;:{&quot;view_name&quot;:&quot;zoeken&quot;,&quot;view_display_id&quot;:&quot;block&quot;,&quot;view_args&quot;:&quot;&quot;,&quot;view_path&quot;:&quot;node\/99&quot;,&quot;view_base_path&quot;:null,&quot;view_dom_id&quot;:&quot;f2bb4d79020da034afcf982945205b53&quot;,&quot;pager_element&quot;:0}}}});&lt;/p&gt;&lt;p&gt;//--&gt;&lt;!]]&gt;&lt;/p&gt;&lt;p&gt;&lt;/script&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</otherinfo>
+        <reference>&lt;p&gt;&lt;/p&gt;</reference>
+        <cweid>200</cweid>
+        <wascid>13</wascid>
+        <sourceid>3</sourceid>
+    </alertitem>
+    <alertitem>
+        <pluginid>10202</pluginid>
+        <alert>Absence of Anti-CSRF Tokens</alert>
+        <name>Absence of Anti-CSRF Tokens</name>
+        <riskcode>1</riskcode>
+        <confidence>2</confidence>
+        <riskdesc>Low (Medium)</riskdesc>
+        <desc>&lt;p&gt;No Anti-CSRF tokens were found in a HTML submission form.&lt;/p&gt;&lt;p&gt;A cross-site request forgery is an attack that involves forcing a victim to send an HTTP request to a target destination without their knowledge or intent in order to perform an action as the victim. The underlying cause is application functionality using predictable URL/form actions in a repeatable way. The nature of the attack is that CSRF exploits the trust that a web site has for a user. By contrast, cross-site scripting (XSS) exploits the trust that a user has for a web site. Like XSS, CSRF attacks are not necessarily cross-site, but they can be. Cross-site request forgery is also known as CSRF, XSRF, one-click attack, session riding, confused deputy, and sea surf.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;CSRF attacks are effective in a number of situations, including:&lt;/p&gt;&lt;p&gt;    * The victim has an active session on the target site.&lt;/p&gt;&lt;p&gt;    * The victim is authenticated via HTTP auth on the target site.&lt;/p&gt;&lt;p&gt;    * The victim is on the same local network as the target site.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;CSRF has primarily been used to perform an action against a target site using the victim&apos;s privileges, but recent techniques have been discovered to disclose information by gaining access to the response. The risk of information disclosure is dramatically increased when the target site is vulnerable to XSS, because XSS can be used as a platform for CSRF, allowing the attack to operate within the bounds of the same-origin policy.&lt;/p&gt;</desc>
+        <instances>
+            <instance>
+                <uri>http://testsite/search/drupal-dast-cdn/assets/svg/logo/logo.svg</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/login/</uri>
+                <method>POST</method>
+                <evidence>&lt;form action=&quot;/user/login/&quot; method=&quot;post&quot; id=&quot;user-login&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/sites/default/files/styles/themecard/public/drupal-dast-cdn/assets/favicon/apple-icon-120x120.png</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/sites/default/files/styles/themecard/public/Pensioen%20en%20gezin.jpg?itok=0ce1BDK5</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/register/</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/node/add/drupal-dast-cdn/assets/favicon/favicon-32x32.png</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/register/drupal-dast-cdn/assets/favicon/apple-icon-180x180.png</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/login</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/drupal-dast-cdn/drupal-dast-cdn/assets/svg/logo/logo.svg</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/sites/default/files/styles/themecard/public/drupal-dast-cdn/assets/favicon/favicon-16x16.png</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/sites/default/files/styles/themecard/public/drupal-dast-cdn/assets/favicon/apple-icon-72x72.png</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/login/drupal-dast-cdn/assets/favicon/apple-icon.png</uri>
+                <method>GET</method>
+                <evidence>&lt;form action=&quot;/user/login/drupal-dast-cdn/assets/favicon/apple-icon.png&quot; method=&quot;post&quot; id=&quot;user-login&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/admin/drupal-dast-cdn/assets/favicon/apple-icon-180x180.png</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/comment/reply/drupal-dast-cdn/assets/svg/logo/logo-footer.svg</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/drupal-dast-cdn/assets/svg/logo</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/node/add/drupal-dast-cdn/assets/favicon/favicon-16x16.png</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/register/drupal-dast-cdn/assets/favicon/apple-icon-76x76.png</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/sites/default/files/drupal-dast-cdn/assets/svg/logo/logo-footer.svg</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/user/register</uri>
+                <method>POST</method>
+                <evidence>&lt;form class=&quot;user-info-from-cookie&quot; enctype=&quot;multipart/form-data&quot; action=&quot;/user/register&quot; method=&quot;post&quot; id=&quot;user-register-form&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+            <instance>
+                <uri>http://testsite/drupal-dast-cdn/assets/svg/logo/logo-footer.svg</uri>
+                <method>GET</method>
+                <evidence>&lt;form class=&quot;ctools-auto-submit-full-form&quot; action=&quot;/&quot; method=&quot;get&quot; id=&quot;views-exposed-form-zoeken-block&quot; accept-charset=&quot;UTF-8&quot;&gt;</evidence>
+            </instance>
+        </instances>
+        <count>352</count>
+        <solution>&lt;p&gt;Phase: Architecture and Design&lt;/p&gt;&lt;p&gt;Use a vetted library or framework that does not allow this weakness to occur or provides constructs that make this weakness easier to avoid.&lt;/p&gt;&lt;p&gt;For example, use anti-CSRF packages such as the OWASP CSRFGuard.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Phase: Implementation&lt;/p&gt;&lt;p&gt;Ensure that your application is free of cross-site scripting issues, because most CSRF defenses can be bypassed using attacker-controlled script.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Phase: Architecture and Design&lt;/p&gt;&lt;p&gt;Generate a unique nonce for each form, place the nonce into the form, and verify the nonce upon receipt of the form. Be sure that the nonce is not predictable (CWE-330).&lt;/p&gt;&lt;p&gt;Note that this can be bypassed using XSS.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Identify especially dangerous operations. When the user performs a dangerous operation, send a separate confirmation request to ensure that the user intended to perform that operation.&lt;/p&gt;&lt;p&gt;Note that this can be bypassed using XSS.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Use the ESAPI Session Management control.&lt;/p&gt;&lt;p&gt;This control includes a component for CSRF.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Do not use the GET method for any request that triggers a state change.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Phase: Implementation&lt;/p&gt;&lt;p&gt;Check the HTTP Referer header to see if the request originated from an expected page. This could break legitimate functionality, because users or proxies may have disabled sending the Referer for privacy reasons.&lt;/p&gt;</solution>
+        <otherinfo>&lt;p&gt;No known Anti-CSRF token [anticsrf, CSRFToken, __RequestVerificationToken, csrfmiddlewaretoken, authenticity_token, anoncsrf, csrf_token] was found in the following HTML form: [Form 1: &quot;edit-keys&quot; &quot;edit-submit-zoeken&quot; ].&lt;/p&gt;</otherinfo>
+        <reference>&lt;p&gt;http://projects.webappsec.org/Cross-Site-Request-Forgery&lt;/p&gt;&lt;p&gt;http://cwe.mitre.org/data/definitions/352.html&lt;/p&gt;</reference>
+        <cweid>352</cweid>
+        <wascid>9</wascid>
+        <sourceid>3</sourceid>
+    </alertitem>
+    <alertitem>
+        <pluginid>90033</pluginid>
+        <alert>Loosely Scoped Cookie</alert>
+        <name>Loosely Scoped Cookie</name>
+        <riskcode>0</riskcode>
+        <confidence>1</confidence>
+        <riskdesc>Informational (Low)</riskdesc>
+        <desc>&lt;p&gt;Cookies can be scoped by domain or path. This check is only concerned with domain scope.The domain scope applied to a cookie determines which domains can access it. For example, a cookie can be scoped strictly to a subdomain e.g. www.nottrusted.com, or loosely scoped to a parent domain e.g. nottrusted.com. In the latter case, any subdomain of nottrusted.com can access the cookie. Loosely scoped cookies are common in mega-applications like google.com and live.com. Cookies set from a subdomain like app.foo.bar are transmitted only to that domain by the browser. However, cookies scoped to a parent-level domain may be transmitted to the parent, or any subdomain of the parent.&lt;/p&gt;</desc>
+        <instances>
+            <instance>
+                <uri>http://testsite/user/login</uri>
+                <method>POST</method>
+            </instance>
+            <instance>
+                <uri>http://testsite/update.php</uri>
+                <method>GET</method>
+            </instance>
+        </instances>
+        <count>2</count>
+        <solution>&lt;p&gt;Always scope cookies to a FQDN (Fully Qualified Domain Name).&lt;/p&gt;</solution>
+        <otherinfo>&lt;p&gt;The origin domain used for comparison was: &lt;/p&gt;&lt;p&gt;drupal&lt;/p&gt;&lt;p&gt;SESS1a16b869ad6213440f9466338d3066fd=iB6aDHMjHogzZYBkK5sdjmIr_NaVA0DWlvzxfq-ffok&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</otherinfo>
+        <reference>&lt;p&gt;https://example2.org</reference>
+        <cweid>565</cweid>
+        <wascid>15</wascid>
+        <sourceid>3</sourceid>
+    </alertitem>
+    <alertitem>
+        <pluginid>10020</pluginid>
+        <alert>X-Frame-Options Header Not Set</alert>
+        <name>X-Frame-Options Header Not Set</name>
+        <riskcode>2</riskcode>
+        <confidence>2</confidence>
+        <riskdesc>Medium (Medium)</riskdesc>
+        <desc>&lt;p&gt;X-Frame-Options header is not included in the HTTP response to protect against &apos;ClickJacking&apos; attacks.&lt;/p&gt;</desc>
+        <instances>
+            <instance>
+                <uri>http://testsite/install.php</uri>
+                <method>GET</method>
+                <param>X-Frame-Options</param>
+            </instance>
+            <instance>
+                <uri>http://testsite/xmlrpc.php</uri>
+                <method>GET</method>
+                <param>X-Frame-Options</param>
+            </instance>
+        </instances>
+        <count>2</count>
+        <solution>&lt;p&gt;Most modern Web browsers support the X-Frame-Options HTTP header. Ensure it&apos;s set on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it&apos;s part of a FRAMESET) then you&apos;ll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. ALLOW-FROM allows specific websites to frame the web page in supported web browsers).&lt;/p&gt;</solution>
+        <reference>&lt;p&gt;http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx&lt;/p&gt;</reference>
+        <cweid>16</cweid>
+        <wascid>15</wascid>
+        <sourceid>3</sourceid>
+    </alertitem>
+</alerts></site><site name="http://ocsp.digicert.com" host="ocsp.digicert.com" port="80" ssl="false"><alerts><alertitem>
+    <pluginid>10021</pluginid>
+    <alert>X-Content-Type-Options Header Missing</alert>
+    <name>X-Content-Type-Options Header Missing</name>
+    <riskcode>1</riskcode>
+    <confidence>2</confidence>
+    <riskdesc>Low (Medium)</riskdesc>
+    <desc>&lt;p&gt;The Anti-MIME-Sniffing header X-Content-Type-Options was not set to &apos;nosniff&apos;. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.&lt;/p&gt;</desc>
+    <instances>
+        <instance>
+            <uri>http://ocsp.digicert.com/</uri>
+            <method>POST</method>
+            <param>X-Content-Type-Options</param>
+        </instance>
+    </instances>
+    <count>1</count>
+    <solution>&lt;p&gt;Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to &apos;nosniff&apos; for all web pages.&lt;/p&gt;&lt;p&gt;If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.&lt;/p&gt;</solution>
+    <otherinfo>&lt;p&gt;This issue still applies to error type pages (401, 403, 500, etc) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.&lt;/p&gt;&lt;p&gt;At &quot;High&quot; threshold this scanner will not alert on client or server error responses.&lt;/p&gt;</otherinfo>
+    <reference>&lt;p&gt;http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx&lt;/p&gt;&lt;p&gt;https://example2.org</reference>
+    <cweid>16</cweid>
+    <wascid>15</wascid>
+    <sourceid>3</sourceid>
+</alertitem>
+</alerts></site></OWASPZAPReport>


### PR DESCRIPTION
In the current version of ZAP, the report XML can contain muliple `<Site />` elements. In the zap-sonar-plugin, all sites will be looped over, but only the last site gets eventually reported. I added support to add the alertitems for all sites.

In the current version of ZAP, the report XML contains `<instance/>` elements that contain the `<uri/>`, `<method/>` etc.. The plugin didn't evaluate the `<instances/>`, so URI etc. weren't present in the description. I added handling of those elements.

I also added a view rules that are evaluated in the baseline scan and need to be present on the SonarQube server (best effort).