### PR TITLE
#78 add missing logic to take parameter "branch"

### DIFF
--- a/conf/webpack/webpack.config.js
+++ b/conf/webpack/webpack.config.js
@@ -34,6 +34,7 @@ module.exports = {
     // Register the Sonar* globals as packages, to simplify importing.
     // See src/main/js/common/api.js for more information on what is exposed
     // in SonarRequest.
+    "sonar-helpers": "SonarHelpers",
     "sonar-request": "SonarRequest",
     "sonar-measures": "SonarMeasures",
     // See src/main/js/portfolio_page/components/MeasuresHistory.js for some

--- a/src/main/js/report_page/components/ZapReportApp.js
+++ b/src/main/js/report_page/components/ZapReportApp.js
@@ -1,13 +1,23 @@
 import React from "react";
 
 import { DeferredSpinner } from "sonar-components";
+import { isBranch, isPullRequest } from "sonar-helpers";
 import { getJSON } from "sonar-request";
 
 const findZapReport = (options) => {
-  return getJSON("/api/measures/component", {
-    component: options.component.key,
-    metricKeys: "html_report",
-  }).then(function (response) {
+  var request = {
+    component : options.component.key,
+    metricKeys : "html_report"
+  };
+  
+  // branch and pullRequest are internal parameters for /api/measures/component
+  if (isBranch(options.branchLike)) {
+    request.branch = options.branchLike.name;
+  } else if (isPullRequest(options.branchLike)) {
+    request.pullRequest = options.branchLike.key;
+  }
+  
+  return getJSON("/api/measures/component", request).then(function(response) {
     var report = response.component.measures.find((measure) => {
       return measure.metric === "html_report";
     });


### PR DESCRIPTION
Tested it with SonarQube Community Branch Plugin.

Passing branch parameter 

```
-Dsonar.branch.name=develop
```

Result:

Zap Scanning Report is able to be displayed under branch "develop" now.

![image](https://user-images.githubusercontent.com/35857179/109446450-af44ff00-7a7c-11eb-9f6c-d2249f2da463.png)

There will be no Zap Scanning Report as I haven't pushed it to branch "master"

![image](https://user-images.githubusercontent.com/35857179/109446501-c126a200-7a7c-11eb-921e-a9e5dd8a5a4c.png)
